### PR TITLE
fix: allow fetch() during install/activate lifecycle events

### DIFF
--- a/docs/serviceworker.md
+++ b/docs/serviceworker.md
@@ -65,6 +65,30 @@ self.addEventListener("install", (event) => {
 - Install completes when all `waitUntil` promises resolve
 - Install fails if any promise rejects
 - 30-second timeout for all promises
+- `fetch()` with relative URLs routes through your own fetch handler
+
+#### Using fetch() During Install
+
+You can use `fetch()` during install to generate static content through your own routes:
+
+```typescript
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    (async () => {
+      // Fetch through your own router to generate static pages
+      const response = await fetch("/404.html");
+      const html = await response.text();
+
+      // Write to static output
+      const dir = await directories.open("public");
+      const file = await dir.getFileHandle("404.html", { create: true });
+      const writable = await file.createWritable();
+      await writable.write(html);
+      await writable.close();
+    })()
+  );
+});
+```
 
 ### 3. Activating
 
@@ -94,10 +118,11 @@ self.addEventListener("activate", (event) => {
 - Activation completes when all `waitUntil` promises resolve
 - Activation fails if any promise rejects
 - 30-second timeout for all promises
+- `fetch()` with relative URLs routes through your own fetch handler
 
 ### 4. Activated
 
-The worker is ready to handle requests. `fetch` events now fire.
+The worker is ready to handle external requests. `fetch` events fire for incoming HTTP requests.
 
 ---
 

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -1324,8 +1324,12 @@ export class ShovelServiceWorkerRegistration
 	 * @param event - The fetch event to handle (created by platform adapter)
 	 */
 	async [kHandleRequest](event: ShovelFetchEvent): Promise<Response> {
-		if (this[kServiceWorker].state !== "activated") {
-			throw new Error("ServiceWorker not activated");
+		// Allow fetch during any lifecycle state after parsing (installing, installed,
+		// activating, activated). This enables fetch() during install/activate handlers
+		// for use cases like SSG cache warming. Fetch handlers are registered during
+		// module evaluation, before lifecycle events dispatch.
+		if (this[kServiceWorker].state === "parsed") {
+			throw new Error("ServiceWorker not initialized");
 		}
 
 		// Run the request handling within the AsyncLocalStorage context


### PR DESCRIPTION
## Summary

- Allow `fetch()` with relative URLs to work during `install` and `activate` lifecycle events
- Add documentation and example for SSG use case

## Problem

`fetch()` calls failed with "ServiceWorker not activated" during the `install` lifecycle event, blocking cache warming use cases for SSG.

```typescript
self.addEventListener('install', (event) => {
  event.waitUntil(
    (async () => {
      // This was failing - "ServiceWorker not activated"
      const response = await fetch('/404.html');
      // ... write to static bucket
    })()
  );
});
```

## Solution

Relaxed the state check in `[kHandleRequest]` from requiring `state === "activated"` to just requiring `state !== "parsed"`. 

This is safe because:
- Fetch handlers are registered during module evaluation (parsing phase)
- By the time `install` fires, all event listeners are already set up
- The self-fetch logic routes through your own fetch handler, not external network

## Changes

- `packages/platform/src/runtime.ts` - Relaxed state check
- `packages/platform/test/serviceworker.test.js` - Added tests for fetch during install/activate
- `docs/serviceworker.md` - Added documentation and example

## Test plan

- [x] Existing serviceworker tests pass (22 tests)
- [x] New tests verify fetch works during install and activate
- [x] Type check passes
- [x] Lint passes

Fixes #30

🤖 Generated with [Claude Code](https://claude.ai/code)