### PR TITLE
feat(assets): enable code splitting for client-side bundles

### DIFF
--- a/src/plugins/assets.ts
+++ b/src/plugins/assets.ts
@@ -491,12 +491,14 @@ export function assetsPlugin(options: AssetsPluginConfig = {}) {
 						writeFileSync(chunkPath, chunk.content);
 
 						// Add chunk to manifest so assets middleware can serve it
+						// Use the full URL as the key to avoid collisions when the same
+						// chunk filename appears in different assetBase directories
 						const chunkUrl = `${basePath}${chunk.filename}`;
 						const chunkHash = createHash("sha256")
 							.update(chunk.content)
 							.digest("hex")
 							.slice(0, HASH_LENGTH);
-						manifest.assets[chunk.filename] = {
+						manifest.assets[chunkUrl] = {
 							source: chunk.filename,
 							output: chunk.filename,
 							url: chunkUrl,
@@ -507,8 +509,7 @@ export function assetsPlugin(options: AssetsPluginConfig = {}) {
 
 						// Also update shared manifest
 						if (sharedManifest) {
-							sharedManifest.assets[chunk.filename] =
-								manifest.assets[chunk.filename];
+							sharedManifest.assets[chunkUrl] = manifest.assets[chunkUrl];
 						}
 					}
 


### PR DESCRIPTION
## Summary

- Enable esbuild's `splitting: true` for transpilable files (TS/JSX) to allow dynamic imports to create separate chunks instead of being inlined
- Handle multiple JS output files (entry file + chunk files)
- Write all chunk files to the output directory alongside the entry
- Add chunks to manifest so assets middleware can serve them
- Use URL as manifest key for chunks to avoid collisions across different assetBase paths
- Add unit tests for code splitting behavior

Fixes #38

## Problem

Dynamic imports in client-side scripts were being inlined instead of creating separate chunks. A large bundle would load everything upfront even when heavy dependencies could be lazy-loaded.

## Solution

When a TypeScript/JavaScript file is imported with `assetBase` and contains dynamic imports:

```typescript
// In client.ts
const { data } = await import("./heavy-dep.ts");
```

The output now includes:
- `client-<hash>.js` - the entry file (URL returned from import)
- `chunk-XXXX.js` - separate chunk files for dynamically imported modules

All files are written to the output directory and added to the manifest so the assets middleware can serve them at runtime.

## Test plan

- [x] `bun test test/assets.test.ts` passes (25 tests including 4 new code splitting tests)
- [x] Website builds successfully
- [x] Existing asset functionality unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)