### PR TITLE
fix: pass through unhandled keypresses in dev server

### DIFF
--- a/src/commands/develop.ts
+++ b/src/commands/develop.ts
@@ -192,6 +192,9 @@ export async function developCommand(
 					case "?":
 						logger.info(SHORTCUTS_HELP);
 						break;
+					default:
+						process.stdout.write(key);
+						break;
 				}
 			});
 		}


### PR DESCRIPTION
## Summary
- Dev server raw mode stdin was swallowing all input except Ctrl+R, Ctrl+L, Ctrl+C, and `?`
- Standard keys like Ctrl+J (newline), Ctrl+Z (suspend), Enter, and regular typing were silently dropped
- Unhandled keypresses now echo to stdout

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Manual: run `shovel develop`, verify Ctrl+J/Enter/typing work, existing shortcuts still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)