### PR TITLE
feat: add @b9g/platform-web for browser Service Worker deployment

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@b9g/platform-bun": "workspace:*",
         "@b9g/platform-cloudflare": "workspace:*",
         "@b9g/platform-node": "workspace:*",
+        "@b9g/platform-web": "workspace:*",
         "@clack/prompts": "^0.7.0",
         "@logtape/logtape": "^2.0.0",
         "commander": "^13.1.0",
@@ -77,26 +78,6 @@
         "@b9g/shovel": "^0.2.17",
       },
       "devDependencies": {
-        "wrangler": "^4.69.0",
-      },
-    },
-    "examples/play": {
-      "name": "shovel-play",
-      "version": "1.0.0",
-      "dependencies": {
-        "@b9g/assets": "^0.2.1",
-        "@b9g/crank": "^0.7.6",
-        "@b9g/crankeditable": "^0.1.0",
-        "@b9g/platform": "workspace:*",
-        "@b9g/platform-cloudflare": "workspace:*",
-        "@b9g/revise": "^0.1.5",
-        "@b9g/router": "workspace:*",
-        "@b9g/shovel": "^0.2.17",
-        "normalize.css": "^8.0.1",
-        "prismjs": "^1.30.0",
-      },
-      "devDependencies": {
-        "@types/prismjs": "^1.26.5",
         "wrangler": "^4.69.0",
       },
     },
@@ -470,8 +451,6 @@
 
     "@b9g/crank": ["@b9g/crank@0.7.7", "", {}, "sha512-QTNvABMxbWG2UX4/losnEe1cLGtGlJDeSKMR65jLffUNt9wtuulZYE3hK9Fwgr+VtB/Q8hLglVrSnnCLnXSQHA=="],
 
-    "@b9g/crankeditable": ["@b9g/crankeditable@0.1.0", "", { "peerDependencies": { "@b9g/crank": ">=0.7.0", "@b9g/revise": ">=0.1.0" } }, "sha512-O9JMGyu5M0EsDs3GT3IZA0VMYzd12acNII2srxyF3AhRUldP0xTikLwpoACumoS8F+Dj6zoKayUfx82NAryKLg=="],
-
     "@b9g/filesystem": ["@b9g/filesystem@workspace:packages/filesystem"],
 
     "@b9g/filesystem-s3": ["@b9g/filesystem-s3@workspace:packages/filesystem-s3"],
@@ -495,8 +474,6 @@
     "@b9g/platform-node": ["@b9g/platform-node@workspace:packages/platform-node"],
 
     "@b9g/platform-web": ["@b9g/platform-web@workspace:packages/platform-web"],
-
-    "@b9g/revise": ["@b9g/revise@0.1.5", "", {}, "sha512-MQcf1irLvtdgg0yp3kPtucPvLuTNLBhwZ6hCJ5O9/Caaf0bgn7EMj3IUfyaekk9ZF/SCO1E6YS4QxjpVAae83A=="],
 
     "@b9g/router": ["@b9g/router@workspace:packages/router"],
 
@@ -885,8 +862,6 @@
     "@types/node": ["@types/node@20.19.33", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw=="],
 
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
-
-    "@types/prismjs": ["@types/prismjs@1.26.6", "", {}, "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="],
 
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
 
@@ -1328,8 +1303,6 @@
 
     "shovel-echo": ["shovel-echo@workspace:examples/echo"],
 
-    "shovel-play": ["shovel-play@workspace:examples/play"],
-
     "shovel-website": ["shovel-website@workspace:website"],
 
     "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
@@ -1494,10 +1467,6 @@
 
     "shovel-echo/wrangler": ["wrangler@4.69.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.14.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260305.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260305.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260305.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-EmVfIM65I5b4ITHe3Y9R7zQyf4NUBQ1leStakMlWiVR9n6VlDwuEltyQI2l3i0JciDnWyR3uqe+T6C08ivniTQ=="],
 
-    "shovel-play/@b9g/shovel": ["@b9g/shovel@0.2.17", "", { "dependencies": { "@b9g/async-context": "^0.2.1", "@b9g/cache": "^0.2.2", "@b9g/filesystem": "^0.2.0", "@b9g/http-errors": "^0.2.1", "@b9g/node-webworker": "^0.2.1", "@b9g/platform": "^0.1.18", "@b9g/platform-bun": "^0.1.16", "@b9g/platform-cloudflare": "^0.1.15", "@b9g/platform-node": "^0.1.17", "@clack/prompts": "^0.7.0", "@logtape/logtape": "^2.0.0", "commander": "^13.1.0", "esbuild": "^0.27.2", "esbuild-plugins-node-modules-polyfill": "^1.8.1", "mime": "^4.0.4", "zod": "^3.23.0" }, "bin": { "shovel": "bin/cli.js", "create-shovel": "bin/create.js", "cli": "bin/cli.js", "create": "bin/create.js" } }, "sha512-MrkxKH2BaE5mg2GUNZb6jJeLOPu6d8Pa0agIwiMhak5Klljl8RulmPK3TlT6eGlL7Qg8SQRplxEZtxVN+o7/6g=="],
-
-    "shovel-play/wrangler": ["wrangler@4.69.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.14.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260305.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260305.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260305.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-EmVfIM65I5b4ITHe3Y9R7zQyf4NUBQ1leStakMlWiVR9n6VlDwuEltyQI2l3i0JciDnWyR3uqe+T6C08ivniTQ=="],
-
     "shovel-website/@b9g/crank": ["@b9g/crank@0.7.6", "", {}, "sha512-SVD3VsdIjISL757MUoDu7xX+fGFwelktDNMGSnfZW4Q9vQD5id9rpUQoOFEBjlDBp5iLEP0mepzURmx3lETPaQ=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
@@ -1589,12 +1558,6 @@
     "shovel-echo/wrangler/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.14.0", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": "^1.20260218.0" }, "optionalPeers": ["workerd"] }, "sha512-XKAkWhi1nBdNsSEoNG9nkcbyvfUrSjSf+VYVPfOto3gLTZVc3F4g6RASCMh6IixBKCG2yDgZKQIHGKtjcnLnKg=="],
 
     "shovel-echo/wrangler/unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
-
-    "shovel-play/wrangler/@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.2", "", {}, "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ=="],
-
-    "shovel-play/wrangler/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.14.0", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": "^1.20260218.0" }, "optionalPeers": ["workerd"] }, "sha512-XKAkWhi1nBdNsSEoNG9nkcbyvfUrSjSf+VYVPfOto3gLTZVc3F4g6RASCMh6IixBKCG2yDgZKQIHGKtjcnLnKg=="],
-
-    "shovel-play/wrangler/unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.17.19", "", { "os": "android", "cpu": "arm" }, "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -80,6 +80,26 @@
         "wrangler": "^4.69.0",
       },
     },
+    "examples/play": {
+      "name": "shovel-play",
+      "version": "1.0.0",
+      "dependencies": {
+        "@b9g/assets": "^0.2.1",
+        "@b9g/crank": "^0.7.6",
+        "@b9g/crankeditable": "^0.1.0",
+        "@b9g/platform": "workspace:*",
+        "@b9g/platform-cloudflare": "workspace:*",
+        "@b9g/revise": "^0.1.5",
+        "@b9g/router": "workspace:*",
+        "@b9g/shovel": "^0.2.17",
+        "normalize.css": "^8.0.1",
+        "prismjs": "^1.30.0",
+      },
+      "devDependencies": {
+        "@types/prismjs": "^1.26.5",
+        "wrangler": "^4.69.0",
+      },
+    },
     "packages/admin": {
       "name": "@b9g/admin",
       "version": "0.1.0",
@@ -297,6 +317,19 @@
         "@types/node": "^18.0.0",
       },
     },
+    "packages/platform-web": {
+      "name": "@b9g/platform-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "@b9g/cache": "workspace:*",
+        "@b9g/filesystem": "workspace:*",
+        "@b9g/platform": "workspace:*",
+        "@logtape/logtape": "^2.0.0",
+      },
+      "devDependencies": {
+        "@b9g/libuild": "^0.1.18",
+      },
+    },
     "packages/router": {
       "name": "@b9g/router",
       "version": "0.2.5",
@@ -437,6 +470,8 @@
 
     "@b9g/crank": ["@b9g/crank@0.7.7", "", {}, "sha512-QTNvABMxbWG2UX4/losnEe1cLGtGlJDeSKMR65jLffUNt9wtuulZYE3hK9Fwgr+VtB/Q8hLglVrSnnCLnXSQHA=="],
 
+    "@b9g/crankeditable": ["@b9g/crankeditable@0.1.0", "", { "peerDependencies": { "@b9g/crank": ">=0.7.0", "@b9g/revise": ">=0.1.0" } }, "sha512-O9JMGyu5M0EsDs3GT3IZA0VMYzd12acNII2srxyF3AhRUldP0xTikLwpoACumoS8F+Dj6zoKayUfx82NAryKLg=="],
+
     "@b9g/filesystem": ["@b9g/filesystem@workspace:packages/filesystem"],
 
     "@b9g/filesystem-s3": ["@b9g/filesystem-s3@workspace:packages/filesystem-s3"],
@@ -458,6 +493,10 @@
     "@b9g/platform-cloudflare": ["@b9g/platform-cloudflare@workspace:packages/platform-cloudflare"],
 
     "@b9g/platform-node": ["@b9g/platform-node@workspace:packages/platform-node"],
+
+    "@b9g/platform-web": ["@b9g/platform-web@workspace:packages/platform-web"],
+
+    "@b9g/revise": ["@b9g/revise@0.1.5", "", {}, "sha512-MQcf1irLvtdgg0yp3kPtucPvLuTNLBhwZ6hCJ5O9/Caaf0bgn7EMj3IUfyaekk9ZF/SCO1E6YS4QxjpVAae83A=="],
 
     "@b9g/router": ["@b9g/router@workspace:packages/router"],
 
@@ -846,6 +885,8 @@
     "@types/node": ["@types/node@20.19.33", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw=="],
 
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
+
+    "@types/prismjs": ["@types/prismjs@1.26.6", "", {}, "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="],
 
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
 
@@ -1287,6 +1328,8 @@
 
     "shovel-echo": ["shovel-echo@workspace:examples/echo"],
 
+    "shovel-play": ["shovel-play@workspace:examples/play"],
+
     "shovel-website": ["shovel-website@workspace:website"],
 
     "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
@@ -1451,6 +1494,10 @@
 
     "shovel-echo/wrangler": ["wrangler@4.69.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.14.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260305.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260305.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260305.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-EmVfIM65I5b4ITHe3Y9R7zQyf4NUBQ1leStakMlWiVR9n6VlDwuEltyQI2l3i0JciDnWyR3uqe+T6C08ivniTQ=="],
 
+    "shovel-play/@b9g/shovel": ["@b9g/shovel@0.2.17", "", { "dependencies": { "@b9g/async-context": "^0.2.1", "@b9g/cache": "^0.2.2", "@b9g/filesystem": "^0.2.0", "@b9g/http-errors": "^0.2.1", "@b9g/node-webworker": "^0.2.1", "@b9g/platform": "^0.1.18", "@b9g/platform-bun": "^0.1.16", "@b9g/platform-cloudflare": "^0.1.15", "@b9g/platform-node": "^0.1.17", "@clack/prompts": "^0.7.0", "@logtape/logtape": "^2.0.0", "commander": "^13.1.0", "esbuild": "^0.27.2", "esbuild-plugins-node-modules-polyfill": "^1.8.1", "mime": "^4.0.4", "zod": "^3.23.0" }, "bin": { "shovel": "bin/cli.js", "create-shovel": "bin/create.js", "cli": "bin/cli.js", "create": "bin/create.js" } }, "sha512-MrkxKH2BaE5mg2GUNZb6jJeLOPu6d8Pa0agIwiMhak5Klljl8RulmPK3TlT6eGlL7Qg8SQRplxEZtxVN+o7/6g=="],
+
+    "shovel-play/wrangler": ["wrangler@4.69.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.14.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260305.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260305.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260305.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-EmVfIM65I5b4ITHe3Y9R7zQyf4NUBQ1leStakMlWiVR9n6VlDwuEltyQI2l3i0JciDnWyR3uqe+T6C08ivniTQ=="],
+
     "shovel-website/@b9g/crank": ["@b9g/crank@0.7.6", "", {}, "sha512-SVD3VsdIjISL757MUoDu7xX+fGFwelktDNMGSnfZW4Q9vQD5id9rpUQoOFEBjlDBp5iLEP0mepzURmx3lETPaQ=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
@@ -1542,6 +1589,12 @@
     "shovel-echo/wrangler/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.14.0", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": "^1.20260218.0" }, "optionalPeers": ["workerd"] }, "sha512-XKAkWhi1nBdNsSEoNG9nkcbyvfUrSjSf+VYVPfOto3gLTZVc3F4g6RASCMh6IixBKCG2yDgZKQIHGKtjcnLnKg=="],
 
     "shovel-echo/wrangler/unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
+
+    "shovel-play/wrangler/@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.2", "", {}, "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ=="],
+
+    "shovel-play/wrangler/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.14.0", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": "^1.20260218.0" }, "optionalPeers": ["workerd"] }, "sha512-XKAkWhi1nBdNsSEoNG9nkcbyvfUrSjSf+VYVPfOto3gLTZVc3F4g6RASCMh6IixBKCG2yDgZKQIHGKtjcnLnKg=="],
+
+    "shovel-play/wrangler/unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.17.19", "", { "os": "android", "cpu": "arm" }, "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@b9g/platform-bun": "workspace:*",
         "@b9g/platform-cloudflare": "workspace:*",
         "@b9g/platform-node": "workspace:*",
+        "@b9g/platform-web": "workspace:*",
         "@clack/prompts": "^0.7.0",
         "@logtape/logtape": "^2.0.0",
         "commander": "^13.1.0",

--- a/bun.lock
+++ b/bun.lock
@@ -297,6 +297,19 @@
         "@types/node": "^18.0.0",
       },
     },
+    "packages/platform-web": {
+      "name": "@b9g/platform-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "@b9g/cache": "workspace:*",
+        "@b9g/filesystem": "workspace:*",
+        "@b9g/platform": "workspace:*",
+        "@logtape/logtape": "^2.0.0",
+      },
+      "devDependencies": {
+        "@b9g/libuild": "^0.1.18",
+      },
+    },
     "packages/router": {
       "name": "@b9g/router",
       "version": "0.2.5",
@@ -438,7 +451,7 @@
 
     "@b9g/crank": ["@b9g/crank@0.7.7", "", {}, "sha512-QTNvABMxbWG2UX4/losnEe1cLGtGlJDeSKMR65jLffUNt9wtuulZYE3hK9Fwgr+VtB/Q8hLglVrSnnCLnXSQHA=="],
 
-    "@b9g/crankdown": ["@b9g/crankdown@0.1.2", "", { "peerDependencies": { "@b9g/crank": ">=0.7.0", "marked": ">=5.0.0" } }, "sha512-Ey7Vx5XPt1GP7cUsUVs//qmz6WiCdIybFwFJ9sokt9d7V03gk/qhSlJbpfdkq8/aRWSuqHvpxiXC0ntPIPanlg=="],
+    "@b9g/crankdown": ["@b9g/crankdown@0.1.3", "", { "peerDependencies": { "@b9g/crank": ">=0.7.0", "marked": ">=5.0.0" } }, "sha512-0gSwBGLhyxCzaB//8e7exw/SbimtjW5INfPtEUJ2zbCGyI7HufVVZmz+WWw7bbVfsMHr11Wv+Zi+AyOIpyDEmA=="],
 
     "@b9g/filesystem": ["@b9g/filesystem@workspace:packages/filesystem"],
 
@@ -461,6 +474,8 @@
     "@b9g/platform-cloudflare": ["@b9g/platform-cloudflare@workspace:packages/platform-cloudflare"],
 
     "@b9g/platform-node": ["@b9g/platform-node@workspace:packages/platform-node"],
+
+    "@b9g/platform-web": ["@b9g/platform-web@workspace:packages/platform-web"],
 
     "@b9g/router": ["@b9g/router@workspace:packages/router"],
 
@@ -1154,7 +1169,7 @@
 
     "make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
 
-    "marked": ["marked@18.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w=="],
+    "marked": ["marked@18.0.7", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA=="],
 
     "matches-selector": ["matches-selector@1.2.0", "", {}, "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA=="],
 
@@ -1454,7 +1469,7 @@
 
     "shovel-echo/wrangler": ["wrangler@4.69.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.14.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260305.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260305.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260305.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-EmVfIM65I5b4ITHe3Y9R7zQyf4NUBQ1leStakMlWiVR9n6VlDwuEltyQI2l3i0JciDnWyR3uqe+T6C08ivniTQ=="],
 
-    "shovel-website/@b9g/shovel": ["@b9g/shovel@0.2.20", "", { "dependencies": { "@b9g/async-context": "^0.2.1", "@b9g/cache": "^0.2.2", "@b9g/filesystem": "^0.2.0", "@b9g/http-errors": "^0.2.1", "@b9g/node-webworker": "^0.2.1", "@b9g/platform": "^0.1.19", "@b9g/platform-bun": "^0.1.17", "@b9g/platform-cloudflare": "^0.1.17", "@b9g/platform-node": "^0.1.17", "@clack/prompts": "^0.7.0", "@logtape/logtape": "^2.0.0", "commander": "^13.1.0", "esbuild": "^0.27.2", "esbuild-plugins-node-modules-polyfill": "^1.8.1", "glob": "^13.0.6", "mime": "^4.0.4", "zod": "^3.23.0" }, "bin": { "shovel": "bin/cli.js", "create-shovel": "bin/create.js", "cli": "bin/cli.js", "create": "bin/create.js" } }, "sha512-ChaVsV8zUO2yxzz8bQTLurNS/2GooY8tj1BHEx5OSBQSWc6GOeeaeDYckwQE+cE7jPFz/MyOgJ/qzj8fPU75Uw=="],
+    "shovel-website/@b9g/shovel": ["@b9g/shovel@0.2.21", "", { "dependencies": { "@b9g/async-context": "^0.2.1", "@b9g/cache": "^0.2.2", "@b9g/filesystem": "^0.2.0", "@b9g/http-errors": "^0.2.1", "@b9g/node-webworker": "^0.2.1", "@b9g/platform": "^0.1.19", "@b9g/platform-bun": "^0.1.17", "@b9g/platform-cloudflare": "^0.1.17", "@b9g/platform-node": "^0.1.17", "@clack/prompts": "^0.7.0", "@logtape/logtape": "^2.0.0", "commander": "^13.1.0", "esbuild": "^0.27.2", "esbuild-plugins-node-modules-polyfill": "^1.8.1", "glob": "^13.0.6", "mime": "^4.0.4", "zod": "^3.23.0" }, "bin": { "shovel": "bin/cli.js", "create-shovel": "bin/create.js", "cli": "bin/cli.js", "create": "bin/create.js" } }, "sha512-tv7AmIHHYeQyImrAOWzqaa0xLvbtKjG4llvbhu4oGnJax5aYPsr1lK0+hJtkSKVSijppB3dwiY6ziAx9HvD8yg=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@b9g/platform-bun": "workspace:*",
     "@b9g/platform-cloudflare": "workspace:*",
     "@b9g/platform-node": "workspace:*",
+    "@b9g/platform-web": "workspace:*",
     "@clack/prompts": "^0.7.0",
     "@logtape/logtape": "^2.0.0",
     "commander": "^13.1.0",

--- a/packages/platform-web/package.json
+++ b/packages/platform-web/package.json
@@ -1,0 +1,100 @@
+{
+  "name": "@b9g/platform-web",
+  "version": "0.1.0",
+  "description": "Browser Service Worker platform adapter for Shovel - runs apps as real browser Service Workers",
+  "type": "module",
+  "scripts": {
+    "build": "libuild build --save",
+    "build:save": "libuild build --save",
+    "publish": "libuild publish",
+    "test": "bun test",
+    "prepublishOnly": "echo 'ERROR: Cannot publish from root directory. Use libuild publish instead.' && exit 1"
+  },
+  "keywords": [
+    "shovel",
+    "platform",
+    "web",
+    "browser",
+    "serviceworker",
+    "pwa"
+  ],
+  "dependencies": {
+    "@b9g/cache": "workspace:*",
+    "@b9g/filesystem": "workspace:*",
+    "@b9g/platform": "workspace:*",
+    "@logtape/logtape": "^2.0.0"
+  },
+  "devDependencies": {
+    "@b9g/libuild": "^0.1.18"
+  },
+  "module": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
+    },
+    "./package.json": "./dist/package.json",
+    "./index": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
+    },
+    "./index.js": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
+    },
+    "./runtime": {
+      "types": "./dist/src/runtime.d.ts",
+      "import": "./dist/src/runtime.js"
+    },
+    "./runtime.js": {
+      "types": "./dist/src/runtime.d.ts",
+      "import": "./dist/src/runtime.js"
+    },
+    "./caches": {
+      "types": "./dist/src/caches.d.ts",
+      "import": "./dist/src/caches.js"
+    },
+    "./caches.js": {
+      "types": "./dist/src/caches.d.ts",
+      "import": "./dist/src/caches.js"
+    },
+    "./directories": {
+      "types": "./dist/src/directories.d.ts",
+      "import": "./dist/src/directories.js"
+    },
+    "./directories.js": {
+      "types": "./dist/src/directories.d.ts",
+      "import": "./dist/src/directories.js"
+    },
+    "./platform": {
+      "types": "./dist/src/platform.d.ts",
+      "import": "./dist/src/platform.js"
+    },
+    "./platform.js": {
+      "types": "./dist/src/platform.d.ts",
+      "import": "./dist/src/platform.js"
+    },
+    "./dev-server": {
+      "types": "./dist/src/dev-server.d.ts",
+      "import": "./dist/src/dev-server.js"
+    },
+    "./dev-server.js": {
+      "types": "./dist/src/dev-server.d.ts",
+      "import": "./dist/src/dev-server.js"
+    },
+    "./async-context-stub": {
+      "types": "./dist/src/async-context-stub.d.ts",
+      "import": "./dist/src/async-context-stub.js"
+    },
+    "./async-context-stub.js": {
+      "types": "./dist/src/async-context-stub.d.ts",
+      "import": "./dist/src/async-context-stub.js"
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bikeshaving/shovel.git",
+    "directory": "packages/platform-web"
+  }
+}

--- a/packages/platform-web/src/async-context-stub.ts
+++ b/packages/platform-web/src/async-context-stub.ts
@@ -1,0 +1,40 @@
+/**
+ * AsyncContext stub for browser Service Worker bundles.
+ *
+ * AsyncContext cannot be polyfilled in browsers — `await` uses the engine's
+ * internal PerformPromiseThen which bypasses any userland hook. This stub
+ * provides the API surface so @b9g/platform/runtime can be bundled.
+ *
+ * run()/get() work within synchronous execution. Context is lost after await.
+ * This is fine — the only consumers (cookieStore, fetchDepth) degrade safely.
+ */
+
+export class AsyncVariable<T> {
+	#defaultValue?: T;
+	constructor(options?: {defaultValue?: T; name?: string}) {
+		this.#defaultValue = options?.defaultValue;
+	}
+	run<R>(_value: T, fn: (...args: unknown[]) => R, ...args: unknown[]): R {
+		return fn(...args);
+	}
+	get(): T | undefined {
+		return this.#defaultValue;
+	}
+	getStore(): T | undefined {
+		return undefined;
+	}
+}
+
+export class AsyncSnapshot {
+	run<R>(fn: (...args: unknown[]) => R, ...args: unknown[]): R {
+		return fn(...args);
+	}
+	static wrap<T, A extends unknown[], R>(
+		fn: (this: T, ...args: A) => R,
+	): (this: T, ...args: A) => R {
+		return fn;
+	}
+}
+
+export const AsyncContext = {Variable: AsyncVariable, Snapshot: AsyncSnapshot};
+export default AsyncContext;

--- a/packages/platform-web/src/caches.ts
+++ b/packages/platform-web/src/caches.ts
@@ -1,0 +1,94 @@
+/**
+ * Web Native Cache
+ *
+ * Wrapper around the browser's native Cache API for use with the factory pattern.
+ */
+
+/**
+ * Store reference to the ORIGINAL native caches object before ServiceWorkerGlobals
+ * overwrites it. This is captured at module load time.
+ *
+ * This is critical because ServiceWorkerGlobals.install() replaces globalThis.caches
+ * with CustomCacheStorage. If we used globalThis.caches directly in #getCache(),
+ * we'd get infinite recursion: CustomCacheStorage.open() -> WebNativeCache ->
+ * #getCache() -> CustomCacheStorage.open() -> ...
+ */
+const nativeCaches: CacheStorage | undefined = globalThis.caches;
+
+/**
+ * WebNativeCache - Wrapper around the browser's native Cache API.
+ * This allows the native cache to be used with the factory pattern.
+ *
+ * Note: This must only be used in a browser Service Worker context where
+ * globalThis.caches is available.
+ */
+export class WebNativeCache implements Cache {
+	#name: string;
+	#cachePromise: Promise<Cache> | null;
+
+	constructor(name: string, _options?: Record<string, unknown>) {
+		this.#name = name;
+		this.#cachePromise = null;
+	}
+
+	#getCache(): Promise<Cache> {
+		if (!this.#cachePromise) {
+			if (!nativeCaches) {
+				throw new Error("Browser caches API not available in this context");
+			}
+			// Use the captured native caches reference, not globalThis.caches
+			// which may have been overwritten by ServiceWorkerGlobals
+			this.#cachePromise = nativeCaches.open(this.#name);
+		}
+		return this.#cachePromise;
+	}
+
+	async add(request: RequestInfo | URL): Promise<void> {
+		const cache = await this.#getCache();
+		return cache.add(request);
+	}
+
+	async addAll(requests: RequestInfo[]): Promise<void> {
+		const cache = await this.#getCache();
+		return cache.addAll(requests);
+	}
+
+	async delete(
+		request: RequestInfo | URL,
+		options?: CacheQueryOptions,
+	): Promise<boolean> {
+		const cache = await this.#getCache();
+		return cache.delete(request, options);
+	}
+
+	async keys(
+		request?: RequestInfo | URL,
+		options?: CacheQueryOptions,
+	): Promise<readonly Request[]> {
+		const cache = await this.#getCache();
+		return cache.keys(request, options);
+	}
+
+	async match(
+		request: RequestInfo | URL,
+		options?: CacheQueryOptions,
+	): Promise<Response | undefined> {
+		const cache = await this.#getCache();
+		return cache.match(request, options);
+	}
+
+	async matchAll(
+		request?: RequestInfo | URL,
+		options?: CacheQueryOptions,
+	): Promise<readonly Response[]> {
+		const cache = await this.#getCache();
+		return cache.matchAll(request, options);
+	}
+
+	async put(request: RequestInfo | URL, response: Response): Promise<void> {
+		const cache = await this.#getCache();
+		return cache.put(request, response);
+	}
+}
+
+export default WebNativeCache;

--- a/packages/platform-web/src/dev-server.ts
+++ b/packages/platform-web/src/dev-server.ts
@@ -1,0 +1,264 @@
+/**
+ * Web Platform Dev Server
+ *
+ * Node.js HTTP server for development of browser Service Worker apps.
+ * This file is dynamically imported and NEVER included in the browser bundle.
+ *
+ * Routes:
+ * - /sw.js → serves the built Service Worker bundle
+ * - /__shovel/events → SSE endpoint for live reload
+ * - /static/* → serves content-hashed assets from dist/public/static/
+ * - Everything else → HTML shell that registers the SW
+ */
+
+import {createServer, type IncomingMessage, type ServerResponse} from "node:http";
+import {readFile, stat} from "node:fs/promises";
+import {dirname, join, extname} from "node:path";
+import type {DevServerOptions, DevServer} from "@b9g/platform/module";
+
+// Simple MIME type map for static assets
+const MIME_TYPES: Record<string, string> = {
+	".js": "application/javascript",
+	".mjs": "application/javascript",
+	".css": "text/css",
+	".html": "text/html",
+	".json": "application/json",
+	".png": "image/png",
+	".jpg": "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif": "image/gif",
+	".svg": "image/svg+xml",
+	".ico": "image/x-icon",
+	".woff": "font/woff",
+	".woff2": "font/woff2",
+	".ttf": "font/ttf",
+	".webp": "image/webp",
+	".avif": "image/avif",
+	".webm": "video/webm",
+	".mp4": "video/mp4",
+	".wasm": "application/wasm",
+};
+
+function getMimeType(filePath: string): string {
+	return MIME_TYPES[extname(filePath).toLowerCase()] || "application/octet-stream";
+}
+
+/**
+ * HTML shell that registers the Service Worker and handles live reload.
+ *
+ * On first visit: registers /sw.js as a module SW → waits for activation → reloads.
+ * SSE listener watches for `reload` events → re-registers SW → reloads page.
+ */
+function getHTMLShell(_port: number): string {
+	return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Shovel Dev</title>
+<style>
+  body { font-family: system-ui, sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; background: #f5f5f5; }
+  .loading { text-align: center; color: #666; }
+  .loading h2 { font-weight: 400; }
+  .spinner { width: 40px; height: 40px; border: 3px solid #ddd; border-top-color: #333; border-radius: 50%; animation: spin 0.8s linear infinite; margin: 0 auto 16px; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+</style>
+</head>
+<body>
+<div class="loading">
+  <div class="spinner"></div>
+  <h2>Starting Service Worker...</h2>
+  <p id="status">Registering...</p>
+</div>
+<script type="module">
+const status = document.getElementById("status");
+
+async function registerAndActivate() {
+  try {
+    if (!("serviceWorker" in navigator)) {
+      status.textContent = "Service Workers not supported in this browser.";
+      return;
+    }
+
+    status.textContent = "Registering Service Worker...";
+    const reg = await navigator.serviceWorker.register("/sw.js", { type: "module" });
+
+    // Wait for the SW to be active
+    const sw = reg.installing || reg.waiting || reg.active;
+    if (sw && sw.state !== "activated") {
+      await new Promise((resolve) => {
+        sw.addEventListener("statechange", () => {
+          if (sw.state === "activated") resolve();
+        });
+      });
+    }
+
+    // If this is the first activation, reload so the SW handles the page
+    if (!navigator.serviceWorker.controller) {
+      status.textContent = "Service Worker activated, reloading...";
+      location.reload();
+      return;
+    }
+
+    // SW is controlling this page — it should have handled the request
+    // If we're still seeing this shell, the SW didn't intercept. Reload once more.
+    status.textContent = "Ready";
+  } catch (err) {
+    status.textContent = "Error: " + err.message;
+    console.error("SW registration failed:", err);
+  }
+}
+
+// Live reload via SSE
+function connectSSE() {
+  const evtSource = new EventSource("/__shovel/events");
+  evtSource.addEventListener("reload", async () => {
+    status.textContent = "Reloading Service Worker...";
+    const reg = await navigator.serviceWorker.getRegistration();
+    if (reg) {
+      await reg.update();
+      // Wait for the new SW to activate
+      const newSW = reg.installing || reg.waiting;
+      if (newSW) {
+        await new Promise((resolve) => {
+          newSW.addEventListener("statechange", () => {
+            if (newSW.state === "activated") resolve();
+          });
+        });
+      }
+    }
+    location.reload();
+  });
+  evtSource.onerror = () => {
+    evtSource.close();
+    // Reconnect after a delay
+    setTimeout(connectSSE, 2000);
+  };
+}
+
+registerAndActivate();
+connectSSE();
+</script>
+</body>
+</html>`;
+}
+
+/**
+ * Create a development server for browser Service Worker apps.
+ */
+export async function createWebDevServer(
+	options: DevServerOptions,
+): Promise<DevServer> {
+	const {port, host, workerPath} = options;
+
+	// Derive public assets directory from worker path
+	// workerPath is e.g. dist/server/worker.js → outDir is dist → public is dist/public
+	const outDir = dirname(dirname(workerPath));
+	const publicDir = join(outDir, "public");
+
+	// SSE clients for live reload
+	const sseClients = new Set<ServerResponse>();
+
+	let currentWorkerPath = workerPath;
+
+	const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+		const url = new URL(req.url || "/", `http://${host}:${port}`);
+		const pathname = url.pathname;
+
+		try {
+			// Serve the Service Worker bundle
+			if (pathname === "/sw.js") {
+				const content = await readFile(currentWorkerPath, "utf-8");
+				res.writeHead(200, {
+					"Content-Type": "application/javascript",
+					"Cache-Control": "no-cache",
+					"Service-Worker-Allowed": "/",
+				});
+				res.end(content);
+				return;
+			}
+
+			// SSE endpoint for live reload
+			if (pathname === "/__shovel/events") {
+				res.writeHead(200, {
+					"Content-Type": "text/event-stream",
+					"Cache-Control": "no-cache",
+					"Connection": "keep-alive",
+					"Access-Control-Allow-Origin": "*",
+				});
+				res.write(":\n\n"); // SSE comment to keep connection alive
+				sseClients.add(res);
+				req.on("close", () => {
+					sseClients.delete(res);
+				});
+				return;
+			}
+
+			// Serve static assets from dist/public/
+			if (pathname.startsWith("/static/")) {
+				const filePath = join(publicDir, pathname);
+				try {
+					const fileStat = await stat(filePath);
+					if (fileStat.isFile()) {
+						const content = await readFile(filePath);
+						res.writeHead(200, {
+							"Content-Type": getMimeType(filePath),
+							"Cache-Control": "public, max-age=31536000, immutable",
+						});
+						res.end(content);
+						return;
+					}
+				} catch {
+					// Fall through to 404
+				}
+
+				res.writeHead(404, {"Content-Type": "text/plain"});
+				res.end("Not Found");
+				return;
+			}
+
+			// Everything else → HTML shell
+			const html = getHTMLShell(port);
+			res.writeHead(200, {
+				"Content-Type": "text/html",
+				"Cache-Control": "no-cache",
+			});
+			res.end(html);
+		} catch (err) {
+			console.error("Dev server error:", err);
+			res.writeHead(500, {"Content-Type": "text/plain"});
+			res.end("Internal Server Error");
+		}
+	});
+
+	await new Promise<void>((resolve) => {
+		server.listen(port, host, () => resolve());
+	});
+
+	const serverUrl = `http://${host}:${port}`;
+
+	return {
+		url: serverUrl,
+
+		async reload(newWorkerPath: string) {
+			currentWorkerPath = newWorkerPath;
+
+			// Notify all SSE clients to reload
+			for (const client of sseClients) {
+				client.write("event: reload\ndata: {}\n\n");
+			}
+		},
+
+		async close() {
+			// Close all SSE connections
+			for (const client of sseClients) {
+				client.end();
+			}
+			sseClients.clear();
+
+			await new Promise<void>((resolve, reject) => {
+				server.close((err) => (err ? reject(err) : resolve()));
+			});
+		},
+	};
+}

--- a/packages/platform-web/src/dev-server.ts
+++ b/packages/platform-web/src/dev-server.ts
@@ -11,10 +11,17 @@
  * - Everything else → HTML shell that registers the SW
  */
 
-import {createServer, type IncomingMessage, type ServerResponse} from "node:http";
+import {
+	createServer,
+	type IncomingMessage,
+	type ServerResponse,
+} from "node:http";
 import {readFile, stat} from "node:fs/promises";
 import {dirname, join, extname} from "node:path";
 import type {DevServerOptions, DevServer} from "@b9g/platform/module";
+import {getLogger} from "@logtape/logtape";
+
+const logger = getLogger(["shovel", "platform"]);
 
 // Simple MIME type map for static assets
 const MIME_TYPES: Record<string, string> = {
@@ -40,7 +47,9 @@ const MIME_TYPES: Record<string, string> = {
 };
 
 function getMimeType(filePath: string): string {
-	return MIME_TYPES[extname(filePath).toLowerCase()] || "application/octet-stream";
+	return (
+		MIME_TYPES[extname(filePath).toLowerCase()] || "application/octet-stream"
+	);
 }
 
 /**
@@ -161,75 +170,80 @@ export async function createWebDevServer(
 
 	let currentWorkerPath = workerPath;
 
-	const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-		const url = new URL(req.url || "/", `http://${host}:${port}`);
-		const pathname = url.pathname;
+	const server = createServer(
+		async (req: IncomingMessage, res: ServerResponse) => {
+			const url = new URL(req.url || "/", `http://${host}:${port}`);
+			const pathname = url.pathname;
 
-		try {
-			// Serve the Service Worker bundle
-			if (pathname === "/sw.js") {
-				const content = await readFile(currentWorkerPath, "utf-8");
-				res.writeHead(200, {
-					"Content-Type": "application/javascript",
-					"Cache-Control": "no-cache",
-					"Service-Worker-Allowed": "/",
-				});
-				res.end(content);
-				return;
-			}
-
-			// SSE endpoint for live reload
-			if (pathname === "/__shovel/events") {
-				res.writeHead(200, {
-					"Content-Type": "text/event-stream",
-					"Cache-Control": "no-cache",
-					"Connection": "keep-alive",
-					"Access-Control-Allow-Origin": "*",
-				});
-				res.write(":\n\n"); // SSE comment to keep connection alive
-				sseClients.add(res);
-				req.on("close", () => {
-					sseClients.delete(res);
-				});
-				return;
-			}
-
-			// Serve static assets from dist/public/
-			if (pathname.startsWith("/static/")) {
-				const filePath = join(publicDir, pathname);
-				try {
-					const fileStat = await stat(filePath);
-					if (fileStat.isFile()) {
-						const content = await readFile(filePath);
-						res.writeHead(200, {
-							"Content-Type": getMimeType(filePath),
-							"Cache-Control": "public, max-age=31536000, immutable",
-						});
-						res.end(content);
-						return;
-					}
-				} catch {
-					// Fall through to 404
+			try {
+				// Serve the Service Worker bundle
+				if (pathname === "/sw.js") {
+					const content = await readFile(currentWorkerPath, "utf-8");
+					res.writeHead(200, {
+						"Content-Type": "application/javascript",
+						"Cache-Control": "no-cache",
+						"Service-Worker-Allowed": "/",
+					});
+					res.end(content);
+					return;
 				}
 
-				res.writeHead(404, {"Content-Type": "text/plain"});
-				res.end("Not Found");
-				return;
-			}
+				// SSE endpoint for live reload
+				if (pathname === "/__shovel/events") {
+					res.writeHead(200, {
+						"Content-Type": "text/event-stream",
+						"Cache-Control": "no-cache",
+						Connection: "keep-alive",
+						"Access-Control-Allow-Origin": "*",
+					});
+					res.write(":\n\n"); // SSE comment to keep connection alive
+					sseClients.add(res);
+					req.on("close", () => {
+						sseClients.delete(res);
+					});
+					return;
+				}
 
-			// Everything else → HTML shell
-			const html = getHTMLShell(port);
-			res.writeHead(200, {
-				"Content-Type": "text/html",
-				"Cache-Control": "no-cache",
-			});
-			res.end(html);
-		} catch (err) {
-			console.error("Dev server error:", err);
-			res.writeHead(500, {"Content-Type": "text/plain"});
-			res.end("Internal Server Error");
-		}
-	});
+				// Serve static assets from dist/public/
+				if (pathname.startsWith("/static/")) {
+					const filePath = join(publicDir, pathname);
+					try {
+						const fileStat = await stat(filePath);
+						if (fileStat.isFile()) {
+							const content = await readFile(filePath);
+							res.writeHead(200, {
+								"Content-Type": getMimeType(filePath),
+								"Cache-Control": "public, max-age=31536000, immutable",
+							});
+							res.end(content);
+							return;
+						}
+					} catch (e) {
+						logger.debug("Static file not found: {path}", {
+							path: filePath,
+							error: e,
+						});
+					}
+
+					res.writeHead(404, {"Content-Type": "text/plain"});
+					res.end("Not Found");
+					return;
+				}
+
+				// Everything else → HTML shell
+				const html = getHTMLShell(port);
+				res.writeHead(200, {
+					"Content-Type": "text/html",
+					"Cache-Control": "no-cache",
+				});
+				res.end(html);
+			} catch (err) {
+				logger.error("Dev server error: {error}", {error: err});
+				res.writeHead(500, {"Content-Type": "text/plain"});
+				res.end("Internal Server Error");
+			}
+		},
+	);
 
 	await new Promise<void>((resolve) => {
 		server.listen(port, host, () => resolve());

--- a/packages/platform-web/src/directories.ts
+++ b/packages/platform-web/src/directories.ts
@@ -1,0 +1,185 @@
+/**
+ * Web Cache Directory
+ *
+ * Read-only FileSystemDirectoryHandle backed by the browser's Cache API.
+ * Assets pre-cached during Service Worker install are served via cache.match().
+ * Used by assetsMiddleware() through self.directories.open("public").
+ */
+
+/**
+ * Capture native caches before ServiceWorkerGlobals overwrites them.
+ */
+const nativeCaches: CacheStorage | undefined = globalThis.caches;
+
+const ASSET_CACHE_NAME = "shovel-assets-v1";
+
+/**
+ * FileSystemFileHandle backed by a cached Response.
+ */
+class WebCacheFileHandle implements FileSystemFileHandle {
+	readonly kind: "file";
+	readonly name: string;
+	#url: string;
+
+	constructor(url: string, name: string) {
+		this.kind = "file";
+		this.#url = url;
+		this.name = name;
+	}
+
+	async getFile(): Promise<File> {
+		if (!nativeCaches) {
+			throw new DOMException("Cache API not available", "NotFoundError");
+		}
+
+		const cache = await nativeCaches.open(ASSET_CACHE_NAME);
+		const response = await cache.match(this.#url);
+
+		if (!response) {
+			throw new DOMException(
+				`A requested file or directory could not be found: ${this.name}`,
+				"NotFoundError",
+			);
+		}
+
+		const blob = await response.blob();
+		const contentType =
+			response.headers.get("content-type") || "application/octet-stream";
+
+		return new File([blob], this.name, {type: contentType});
+	}
+
+	async createWritable(
+		_options?: FileSystemCreateWritableOptions,
+	): Promise<FileSystemWritableFileStream> {
+		throw new DOMException("Cache assets are read-only", "NotAllowedError");
+	}
+
+	async createSyncAccessHandle(): Promise<FileSystemSyncAccessHandle> {
+		throw new DOMException("Sync access not supported", "NotSupportedError");
+	}
+
+	isSameEntry(other: FileSystemHandle): Promise<boolean> {
+		return Promise.resolve(
+			other instanceof WebCacheFileHandle && other.#url === this.#url,
+		);
+	}
+}
+
+/**
+ * Read-only FileSystemDirectoryHandle backed by Cache API.
+ *
+ * Provides access to static assets pre-cached during SW install.
+ * Directory listing is not supported (Cache API doesn't support prefix enumeration easily).
+ */
+class WebCacheDirectoryHandle implements FileSystemDirectoryHandle {
+	readonly kind: "directory";
+	readonly name: string;
+	#basePath: string;
+
+	constructor(basePath = "/") {
+		this.kind = "directory";
+		this.#basePath = basePath.endsWith("/") ? basePath : basePath + "/";
+		this.name = basePath.split("/").filter(Boolean).pop() || "assets";
+	}
+
+	async getFileHandle(
+		name: string,
+		_options?: FileSystemGetFileOptions,
+	): Promise<FileSystemFileHandle> {
+		if (!nativeCaches) {
+			throw new DOMException("Cache API not available", "NotFoundError");
+		}
+
+		const path = this.#basePath + name;
+		const cache = await nativeCaches.open(ASSET_CACHE_NAME);
+		// Try matching against the origin-relative URL
+		const response = await cache.match(new Request(path));
+
+		if (!response) {
+			throw new DOMException(
+				`A requested file or directory could not be found: ${name}`,
+				"NotFoundError",
+			);
+		}
+
+		return new WebCacheFileHandle(path, name);
+	}
+
+	async getDirectoryHandle(
+		name: string,
+		_options?: FileSystemGetDirectoryOptions,
+	): Promise<FileSystemDirectoryHandle> {
+		return new WebCacheDirectoryHandle(this.#basePath + name);
+	}
+
+	async removeEntry(
+		_name: string,
+		_options?: FileSystemRemoveOptions,
+	): Promise<void> {
+		throw new DOMException(
+			"Cache assets directory is read-only",
+			"NotAllowedError",
+		);
+	}
+
+	async resolve(
+		_possibleDescendant: FileSystemHandle,
+	): Promise<string[] | null> {
+		return null;
+	}
+
+	// eslint-disable-next-line require-yield
+	async *entries(): AsyncIterableIterator<[string, FileSystemHandle]> {
+		throw new DOMException(
+			"Directory listing not supported for cache-backed assets",
+			"NotSupportedError",
+		);
+	}
+
+	// eslint-disable-next-line require-yield
+	async *keys(): AsyncIterableIterator<string> {
+		throw new DOMException(
+			"Directory listing not supported for cache-backed assets",
+			"NotSupportedError",
+		);
+	}
+
+	// eslint-disable-next-line require-yield
+	async *values(): AsyncIterableIterator<FileSystemHandle> {
+		throw new DOMException(
+			"Directory listing not supported for cache-backed assets",
+			"NotSupportedError",
+		);
+	}
+
+	[Symbol.asyncIterator](): AsyncIterableIterator<[string, FileSystemHandle]> {
+		return this.entries();
+	}
+
+	isSameEntry(other: FileSystemHandle): Promise<boolean> {
+		return Promise.resolve(
+			other instanceof WebCacheDirectoryHandle &&
+				other.#basePath === this.#basePath,
+		);
+	}
+}
+
+/**
+ * DirectoryClass for browser Cache API-backed assets.
+ * Used by the factory pattern via config defaults.
+ */
+export class WebCacheDirectory extends WebCacheDirectoryHandle {
+	constructor(_name: string, options: {path?: string} = {}) {
+		const basePath = options.path ?? "/";
+		const normalizedBase =
+			basePath === "/"
+				? "/"
+				: basePath.startsWith("/")
+					? basePath
+					: `/${basePath}`;
+		super(normalizedBase);
+	}
+}
+
+export default WebCacheDirectory;

--- a/packages/platform-web/src/directories.ts
+++ b/packages/platform-web/src/directories.ts
@@ -129,8 +129,12 @@ class WebCacheDirectoryHandle implements FileSystemDirectoryHandle {
 		return null;
 	}
 
+	// Return type is `any`: the repo's lib is WebWorker, whose
+	// lib.webworker.asynciterable.d.ts declares these as
+	// FileSystemDirectoryHandleAsyncIterator, which an async generator cannot
+	// satisfy. Typing `any` keeps the class assignable to FileSystemDirectoryHandle.
 	// eslint-disable-next-line require-yield
-	async *entries(): AsyncIterableIterator<[string, FileSystemHandle]> {
+	async *entries(): any {
 		throw new DOMException(
 			"Directory listing not supported for cache-backed assets",
 			"NotSupportedError",
@@ -138,7 +142,7 @@ class WebCacheDirectoryHandle implements FileSystemDirectoryHandle {
 	}
 
 	// eslint-disable-next-line require-yield
-	async *keys(): AsyncIterableIterator<string> {
+	async *keys(): any {
 		throw new DOMException(
 			"Directory listing not supported for cache-backed assets",
 			"NotSupportedError",
@@ -146,14 +150,14 @@ class WebCacheDirectoryHandle implements FileSystemDirectoryHandle {
 	}
 
 	// eslint-disable-next-line require-yield
-	async *values(): AsyncIterableIterator<FileSystemHandle> {
+	async *values(): any {
 		throw new DOMException(
 			"Directory listing not supported for cache-backed assets",
 			"NotSupportedError",
 		);
 	}
 
-	[Symbol.asyncIterator](): AsyncIterableIterator<[string, FileSystemHandle]> {
+	[Symbol.asyncIterator](): any {
 		return this.entries();
 	}
 

--- a/packages/platform-web/src/directories.ts
+++ b/packages/platform-web/src/directories.ts
@@ -129,12 +129,14 @@ class WebCacheDirectoryHandle implements FileSystemDirectoryHandle {
 		return null;
 	}
 
-	// Return type is `any`: the repo's lib is WebWorker, whose
-	// lib.webworker.asynciterable.d.ts declares these as
-	// FileSystemDirectoryHandleAsyncIterator, which an async generator cannot
-	// satisfy. Typing `any` keeps the class assignable to FileSystemDirectoryHandle.
+	// The element type must be the FileSystemFileHandle | FileSystemDirectoryHandle
+	// union (not the FileSystemHandle base): newer lib.webworker declares the
+	// iterator members with the union, and a wider yield type makes the class
+	// unassignable to FileSystemDirectoryHandle.
 	// eslint-disable-next-line require-yield
-	async *entries(): any {
+	async *entries(): AsyncIterableIterator<
+		[string, FileSystemFileHandle | FileSystemDirectoryHandle]
+	> {
 		throw new DOMException(
 			"Directory listing not supported for cache-backed assets",
 			"NotSupportedError",
@@ -142,7 +144,7 @@ class WebCacheDirectoryHandle implements FileSystemDirectoryHandle {
 	}
 
 	// eslint-disable-next-line require-yield
-	async *keys(): any {
+	async *keys(): AsyncIterableIterator<string> {
 		throw new DOMException(
 			"Directory listing not supported for cache-backed assets",
 			"NotSupportedError",
@@ -150,14 +152,18 @@ class WebCacheDirectoryHandle implements FileSystemDirectoryHandle {
 	}
 
 	// eslint-disable-next-line require-yield
-	async *values(): any {
+	async *values(): AsyncIterableIterator<
+		FileSystemFileHandle | FileSystemDirectoryHandle
+	> {
 		throw new DOMException(
 			"Directory listing not supported for cache-backed assets",
 			"NotSupportedError",
 		);
 	}
 
-	[Symbol.asyncIterator](): any {
+	[Symbol.asyncIterator](): AsyncIterableIterator<
+		[string, FileSystemFileHandle | FileSystemDirectoryHandle]
+	> {
 		return this.entries();
 	}
 

--- a/packages/platform-web/src/index.ts
+++ b/packages/platform-web/src/index.ts
@@ -1,0 +1,133 @@
+/**
+ * @b9g/platform-web - Browser Service Worker platform adapter for Shovel
+ *
+ * Provides deployment to static hosting via real browser Service Workers.
+ *
+ * Architecture:
+ * - Uses ServiceWorkerGlobals from @b9g/platform for full feature parity
+ * - Caches use the browser's native Cache API
+ * - Directories use Cache API-backed read-only storage
+ */
+
+import type {
+	PlatformDefaults,
+	EntryPoints,
+	ESBuildConfig,
+	DevServerOptions,
+	DevServer,
+} from "@b9g/platform/module";
+
+// ============================================================================
+// PLATFORM IMPLEMENTATION
+// ============================================================================
+
+/**
+ * Web platform implementation
+ *
+ * Mirrors platform.ts functions as class methods (dual-file pattern).
+ * Primarily for API consistency with other platform packages.
+ */
+export class WebPlatform {
+	readonly name: string;
+
+	constructor() {
+		this.name = "web";
+	}
+
+	/**
+	 * Get entry points for bundling.
+	 *
+	 * Web platform produces a single Service Worker file.
+	 */
+	getEntryPoints(
+		userEntryPath: string,
+		_mode: "development" | "production",
+	): EntryPoints {
+		const safePath = JSON.stringify(userEntryPath);
+
+		const workerCode = `// Browser Service Worker Entry
+import { config } from "shovel:config";
+import { initializeRuntime, createFetchHandler } from "@b9g/platform-web/runtime";
+import assetManifest from "shovel:assets";
+
+// Capture natives BEFORE ServiceWorkerGlobals.install() replaces them
+const nativeAddEventListener = self.addEventListener.bind(self);
+const nativeCaches = self.caches;
+
+// Initialize runtime (installs ServiceWorker globals)
+const registration = await initializeRuntime(config);
+
+// Import user code (registers event handlers via shimmed self.addEventListener)
+await import(${safePath});
+
+const handleFetch = createFetchHandler(registration);
+
+nativeAddEventListener("install", (event) => {
+  event.waitUntil((async () => {
+    // Pre-cache static assets
+    const cache = await nativeCaches.open("shovel-assets-v1");
+    const urls = Object.values(assetManifest.assets || {}).filter(e => e && e.url).map(e => e.url);
+    if (urls.length) await cache.addAll(urls);
+    await self.skipWaiting();
+  })());
+});
+
+nativeAddEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+nativeAddEventListener("fetch", (event) => {
+  event.respondWith(handleFetch(event.request));
+});
+`;
+
+		return {worker: workerCode};
+	}
+
+	/**
+	 * Get Cloudflare-specific esbuild configuration
+	 */
+	getESBuildConfig(): ESBuildConfig {
+		return {
+			platform: "browser",
+			conditions: ["worker", "browser"],
+			external: [],
+			define: {
+				"process.env": "({MODE:'production'})",
+			},
+			alias: {
+				"@b9g/async-context": "@b9g/platform-web/async-context-stub",
+			},
+		};
+	}
+
+	/**
+	 * Get web platform defaults for config generation
+	 */
+	getDefaults(): PlatformDefaults {
+		return {
+			caches: {
+				"*": {
+					module: "@b9g/platform-web/caches",
+					export: "WebNativeCache",
+				},
+			},
+			directories: {
+				public: {
+					module: "@b9g/platform-web/directories",
+					export: "WebCacheDirectory",
+				},
+			},
+		};
+	}
+
+	/**
+	 * Create a dev server for browser Service Workers.
+	 */
+	async createDevServer(options: DevServerOptions): Promise<DevServer> {
+		const {createWebDevServer} = await import("./dev-server.js");
+		return createWebDevServer(options);
+	}
+}
+
+export default WebPlatform;

--- a/packages/platform-web/src/platform.ts
+++ b/packages/platform-web/src/platform.ts
@@ -1,0 +1,134 @@
+/**
+ * Web Platform Module
+ *
+ * Build-time and dev-time functions for browser Service Workers.
+ * Runtime functions are in ./runtime.ts
+ */
+
+import type {
+	EntryPoints,
+	ESBuildConfig,
+	PlatformDefaults,
+	DevServerOptions,
+	DevServer,
+} from "@b9g/platform/module";
+
+// ============================================================================
+// PLATFORM IDENTITY
+// ============================================================================
+
+export const name = "web";
+
+// ============================================================================
+// BUILD-TIME FUNCTIONS
+// ============================================================================
+
+/**
+ * Get entry points for bundling.
+ *
+ * Web platform produces a single Service Worker file.
+ * The generated code captures native SW APIs before ServiceWorkerGlobals.install()
+ * replaces them, then bridges real SW fetch events to Shovel's dispatchRequest().
+ */
+export function getEntryPoints(
+	userEntryPath: string,
+	_mode: "development" | "production",
+): EntryPoints {
+	const safePath = JSON.stringify(userEntryPath);
+
+	const workerCode = `// Browser Service Worker Entry
+import { config } from "shovel:config";
+import { initializeRuntime, createFetchHandler } from "@b9g/platform-web/runtime";
+import assetManifest from "shovel:assets";
+
+// Capture natives BEFORE ServiceWorkerGlobals.install() replaces them
+const nativeAddEventListener = self.addEventListener.bind(self);
+const nativeCaches = self.caches;
+
+// Initialize runtime (installs ServiceWorker globals)
+const registration = await initializeRuntime(config);
+
+// Import user code (registers event handlers via shimmed self.addEventListener)
+await import(${safePath});
+
+const handleFetch = createFetchHandler(registration);
+
+nativeAddEventListener("install", (event) => {
+  event.waitUntil((async () => {
+    // Pre-cache static assets
+    const cache = await nativeCaches.open("shovel-assets-v1");
+    const urls = Object.values(assetManifest.assets || {}).filter(e => e && e.url).map(e => e.url);
+    if (urls.length) await cache.addAll(urls);
+    await self.skipWaiting();
+  })());
+});
+
+nativeAddEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+nativeAddEventListener("fetch", (event) => {
+  event.respondWith(handleFetch(event.request));
+});
+`;
+
+	return {worker: workerCode};
+}
+
+/**
+ * Get ESBuild configuration for browser Service Workers.
+ *
+ * Uses browser platform with worker conditions. No externals — everything
+ * must be bundled into the SW since there's no runtime module system.
+ */
+export function getESBuildConfig(): ESBuildConfig {
+	return {
+		platform: "browser",
+		conditions: ["worker", "browser"],
+		external: [],
+		define: {
+			"process.env": "({MODE:'production'})",
+		},
+		alias: {
+			"@b9g/async-context": "@b9g/platform-web/async-context-stub",
+		},
+	};
+}
+
+/**
+ * Get platform defaults for config generation.
+ *
+ * These become static imports in the bundled config.
+ */
+export function getDefaults(): PlatformDefaults {
+	return {
+		caches: {
+			"*": {
+				module: "@b9g/platform-web/caches",
+				export: "WebNativeCache",
+			},
+		},
+		directories: {
+			public: {
+				module: "@b9g/platform-web/directories",
+				export: "WebCacheDirectory",
+			},
+		},
+	};
+}
+
+// ============================================================================
+// DEV-TIME FUNCTIONS
+// ============================================================================
+
+/**
+ * Create a dev server for browser Service Workers.
+ *
+ * Dynamically imports the Node.js HTTP server to keep it out of browser bundles.
+ */
+export async function createDevServer(
+	options: DevServerOptions,
+): Promise<DevServer> {
+	const {createWebDevServer} = await import("./dev-server.js");
+	return createWebDevServer(options);
+}

--- a/packages/platform-web/src/runtime.ts
+++ b/packages/platform-web/src/runtime.ts
@@ -1,0 +1,108 @@
+/**
+ * Web Platform Runtime
+ *
+ * This module provides runtime initialization for browser Service Workers.
+ * It is imported by the entry wrapper, not by user code.
+ */
+
+import {
+	ServiceWorkerGlobals,
+	ShovelServiceWorkerRegistration,
+	ShovelFetchEvent,
+	CustomLoggerStorage,
+	configureLogging,
+	createCacheFactory,
+	createDirectoryFactory,
+	runLifecycle,
+	dispatchRequest,
+	type ShovelConfig,
+} from "@b9g/platform/runtime";
+
+import {CustomCacheStorage} from "@b9g/cache";
+import {CustomDirectoryStorage} from "@b9g/filesystem";
+import {getLogger} from "@logtape/logtape";
+
+export type {ShovelConfig};
+
+// ============================================================================
+// RUNTIME INITIALIZATION
+// ============================================================================
+
+// Module-level state (initialized once when module loads)
+let _registration: ShovelServiceWorkerRegistration | null = null;
+let _globals: ServiceWorkerGlobals | null = null;
+
+/**
+ * Initialize the web runtime with ServiceWorkerGlobals
+ *
+ * @param config - Shovel configuration from shovel:config virtual module
+ * @returns The ServiceWorker registration for handling requests
+ */
+export async function initializeRuntime(
+	config: ShovelConfig,
+): Promise<ShovelServiceWorkerRegistration> {
+	if (_registration) {
+		return _registration;
+	}
+
+	// Configure logging first
+	if (config.logging) {
+		await configureLogging(config.logging);
+	}
+
+	_registration = new ShovelServiceWorkerRegistration();
+
+	// Create cache storage with config-driven factory
+	const caches = new CustomCacheStorage(
+		createCacheFactory({configs: config.caches ?? {}}),
+	);
+
+	// Create directory storage with config-driven factory
+	const directories = new CustomDirectoryStorage(
+		createDirectoryFactory(config.directories ?? {}),
+	);
+
+	// Create ServiceWorkerGlobals
+	_globals = new ServiceWorkerGlobals({
+		registration: _registration,
+		caches,
+		directories,
+		loggers: new CustomLoggerStorage((cats) => getLogger(cats)),
+	});
+
+	// Install globals (caches, directories, cookieStore, addEventListener, etc.)
+	_globals.install();
+
+	return _registration;
+}
+
+/**
+ * Create a fetch handler for the browser Service Worker.
+ *
+ * Lifecycle (install/activate) is deferred to the first request.
+ * Returns an async handler: (request: Request) => Promise<Response>
+ */
+export function createFetchHandler(
+	registration: ShovelServiceWorkerRegistration,
+): (request: Request) => Promise<Response> {
+	// Defer lifecycle to first request
+	let lifecyclePromise: Promise<void> | null = null;
+
+	return async (request: Request): Promise<Response> => {
+		// Run lifecycle once on first request
+		if (!lifecyclePromise) {
+			lifecyclePromise = runLifecycle(registration, "activate");
+		}
+		await lifecyclePromise;
+
+		// Create a ShovelFetchEvent and dispatch
+		const event = new ShovelFetchEvent(request, {
+			platformWaitUntil: (_promise) => {
+				// In browser SW, we don't have a ctx.waitUntil — the real
+				// SW event.waitUntil is handled at the outer entry level
+			},
+		});
+
+		return dispatchRequest(registration, event);
+	};
+}

--- a/packages/platform-web/tsconfig.json
+++ b/packages/platform-web/tsconfig.json
@@ -1,0 +1,27 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
+		"declaration": true,
+		"declarationMap": true,
+		"outDir": "./dist",
+		"strict": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"noEmit": false,
+		"lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
+		"composite": true,
+		"types": []
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.js"],
+	"references": [
+		{"path": "../platform"},
+		{"path": "../cache"},
+		{"path": "../filesystem"}
+	]
+}

--- a/packages/platform/src/module.ts
+++ b/packages/platform/src/module.ts
@@ -33,6 +33,8 @@ export interface ESBuildConfig {
 	external?: string[];
 	/** Define replacements */
 	define?: Record<string, string>;
+	/** Module aliases (maps import paths to replacement paths) */
+	alias?: Record<string, string>;
 }
 
 /**

--- a/src/utils/bundler.ts
+++ b/src/utils/bundler.ts
@@ -360,7 +360,10 @@ export class ServerBundler {
 				__SHOVEL_OUTDIR__: JSON.stringify(outputDir),
 				__SHOVEL_GIT__: JSON.stringify(getGitSHA(this.#projectRoot)),
 			},
-			alias: userBuildConfig?.alias,
+			alias: {
+				...(platformESBuildConfig.alias ?? {}),
+				...(userBuildConfig?.alias ?? {}),
+			},
 			external,
 			sourcemap,
 			minify,

--- a/src/utils/bundler.ts
+++ b/src/utils/bundler.ts
@@ -367,7 +367,10 @@ export class ServerBundler {
 				__SHOVEL_OUTDIR__: JSON.stringify(outputDir),
 				__SHOVEL_GIT__: JSON.stringify(getGitSHA(this.#projectRoot)),
 			},
-			alias: userBuildConfig?.alias,
+			alias: {
+				...(platformESBuildConfig.alias ?? {}),
+				...(userBuildConfig?.alias ?? {}),
+			},
 			external,
 			sourcemap,
 			minify,

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -37,9 +37,14 @@ export async function loadPlatformModule(
 			return module as PlatformModule;
 		}
 
+		case "web": {
+			const module = await import("@b9g/platform-web/platform");
+			return module as PlatformModule;
+		}
+
 		default:
 			throw new Error(
-				`Unknown platform: ${platformName}. Valid platforms: node, bun, cloudflare`,
+				`Unknown platform: ${platformName}. Valid platforms: node, bun, cloudflare, web`,
 			);
 	}
 }


### PR DESCRIPTION
## Summary

- New `@b9g/platform-web` package that lets Shovel apps run as real browser Service Workers
- Generated entry captures native SW APIs before `ServiceWorkerGlobals.install()` replaces them, pre-caches assets during SW install, bridges fetch events to `dispatchRequest()`
- Dev server (Node.js HTTP + SSE) serves the SW bundle, static assets, and an HTML shell that registers/reloads the SW
- Browser stub for `@b9g/async-context` — cannot be polyfilled (`await` uses engine-internal `PerformPromiseThen`, bypassing `Promise.prototype`)
- Adds `alias` field to `ESBuildConfig` so platforms can remap modules at build time (used to swap async-context for the stub)

### Files changed outside `packages/platform-web/`
- `packages/platform/src/module.ts` — `alias` field on `ESBuildConfig`
- `src/utils/bundler.ts` — merge platform alias into esbuild options
- `src/utils/platform.ts` — `case "web":` in platform loader

## Test plan

- [ ] `shovel build src/server.ts --platform web` on echo example produces SW bundle
- [ ] `shovel develop src/server.ts --platform web` starts dev server, browser registers SW
- [ ] Existing platform tests pass (194 pass, 0 fail)
- [ ] Build tests pass (17 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)