### PR TITLE
feat: WebSocket support via functional events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,4 +114,4 @@ jobs:
           path: .
 
       - name: Test
-        run: bun test
+        run: bun run test

--- a/bun.lock
+++ b/bun.lock
@@ -291,10 +291,12 @@
         "@b9g/node-webworker": "workspace:*",
         "@b9g/platform": "workspace:*",
         "@logtape/logtape": "^2.0.0",
+        "ws": "^8.0.0",
       },
       "devDependencies": {
         "@b9g/libuild": "^0.1.18",
         "@types/node": "^18.0.0",
+        "@types/ws": "^8.0.0",
       },
     },
     "packages/router": {
@@ -850,6 +852,8 @@
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,2 @@
 [test]
-pathIgnorePatterns = ["**/shovel-wpt/wpt/**"]
+pathIgnorePatterns = ["**/shovel-wpt/wpt/**", "**/cloudflare-*.test.*"]

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "build": "bun run --filter './packages/*' build && libuild build --save",
-    "test": "bun test packages/*/test test && bun test test/cloudflare-build.test.js && bun test test/cloudflare-dev.test.js && bun test test/cloudflare-develop.test.js",
+    "test": "bun test packages/*/test test && bun test --path-ignore-patterns='**/shovel-wpt/**' ./test/cloudflare-build.test.js && bun test --path-ignore-patterns='**/shovel-wpt/**' ./test/cloudflare-dev.test.js && bun test --path-ignore-patterns='**/shovel-wpt/**' ./test/cloudflare-develop.test.js",
     "typecheck": "tsc --noEmit",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "eslint --ext .js,.jsx,.ts,.tsx . --fix",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "build": "bun run --filter './packages/*' build && libuild build --save",
-    "test": "bun test packages/*/test test",
+    "test": "bun test packages/*/test test && bun test test/cloudflare-build.test.js && bun test test/cloudflare-dev.test.js && bun test test/cloudflare-develop.test.js",
     "typecheck": "tsc --noEmit",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "eslint --ext .js,.jsx,.ts,.tsx . --fix",

--- a/packages/platform-bun/src/index.ts
+++ b/packages/platform-bun/src/index.ts
@@ -549,6 +549,7 @@ if (!config.lifecycle) {
 	server = platform.createServer(
 		async (request) => {
 			const r = await pool.handleRequest(request);
+			if ("upgrade" in r) return new Response("Upgrade Required", {status: 426});
 			return r;
 		},
 		{pool, reusePort: config.workers > 1},

--- a/packages/platform-bun/src/index.ts
+++ b/packages/platform-bun/src/index.ts
@@ -324,10 +324,22 @@ export class BunPlatform {
 					) {
 						const result = await pool.handleRequest(request);
 						if ("upgrade" in result) {
-							server.upgrade(request, {
+							const upgraded = server.upgrade(request, {
 								data: {connectionID: result.connectionID},
 							});
-							return undefined as any;
+							if (upgraded) {
+								return undefined as any;
+							}
+							// Bun rejected the handshake — clean up worker-side state
+							pool.sendWebSocketClose(
+								result.connectionID,
+								1006,
+								"Upgrade failed",
+								false,
+							);
+							return new Response("WebSocket upgrade failed", {
+								status: 500,
+							});
 						}
 						// Worker didn't upgrade — return as normal response
 						return result as Response;

--- a/packages/platform-bun/src/index.ts
+++ b/packages/platform-bun/src/index.ts
@@ -407,7 +407,8 @@ export class BunPlatform {
 				close(ws, code, reason) {
 					const {connectionID} = ws.data;
 					if (pool) {
-						pool.sendWebSocketClose(connectionID, code, reason, true);
+						const wasClean = code !== 1006;
+						pool.sendWebSocketClose(connectionID, code, reason, wasClean);
 					}
 					wsConnections.delete(connectionID);
 				},
@@ -455,7 +456,10 @@ export class BunPlatform {
 		this.#server = this.createServer(
 			async (request) => {
 				const result = await pool.handleRequest(request);
-				return result as Response;
+				if ("upgrade" in result) {
+					return new Response("Upgrade Required", {status: 426});
+				}
+				return result;
 			},
 			{pool, port: this.#options.port, host: this.#options.host},
 		);

--- a/packages/platform-bun/src/index.ts
+++ b/packages/platform-bun/src/index.ts
@@ -274,41 +274,92 @@ export class BunPlatform {
 		const requestedPort = options.port ?? this.#options.port;
 		const hostname = options.host ?? this.#options.host;
 		const reusePort = options.reusePort ?? false;
+		const pool = options.pool;
+		const wsConnections = new Map<string, any>();
 
-		// Bun.serve is much simpler than Node.js
-		const server = Bun.serve({
+		// Wire up pool callbacks for outbound WebSocket I/O
+		if (pool) {
+			pool.setWebSocketHandlers({
+				send(connectionID: string, data: string | ArrayBuffer) {
+					const ws = wsConnections.get(connectionID);
+					if (ws) ws.send(data);
+				},
+				close(connectionID: string, code?: number, reason?: string) {
+					const ws = wsConnections.get(connectionID);
+					if (ws) {
+						ws.close(code ?? 1000, reason ?? "");
+						wsConnections.delete(connectionID);
+					}
+				},
+			});
+		}
+
+		const handleError = (error: unknown): Response => {
+			const err = error instanceof Error ? error : new Error(String(error));
+			const httpError = isHTTPError(error)
+				? (error as HTTPError)
+				: new InternalServerError(err.message, {cause: err});
+			if (httpError.status >= 500) {
+				logger.error("Request error: {error}", {error: err});
+			} else {
+				logger.warn("Request error: {status} {error}", {
+					status: httpError.status,
+					error: err,
+				});
+			}
+			const isDev = import.meta.env?.MODE !== "production";
+			return httpError.toResponse(isDev);
+		};
+
+		const server = Bun.serve<{connectionID: string}>({
 			port: requestedPort,
 			hostname,
 			reusePort,
-			async fetch(request) {
+			async fetch(request, server) {
 				try {
+					// Check for WebSocket upgrade when pool is available
+					if (pool && request.headers.get("upgrade") === "websocket") {
+						const result = await pool.handleRequest(request);
+						if ("upgrade" in result) {
+							server.upgrade(request, {
+								data: {connectionID: result.connectionID},
+							});
+							return undefined as any;
+						}
+						// Worker didn't upgrade — return as normal response
+						return result as Response;
+					}
 					return await handler(request);
 				} catch (error) {
-					const err = error instanceof Error ? error : new Error(String(error));
-
-					// Convert to HTTPError for consistent response format
-					const httpError = isHTTPError(error)
-						? (error as HTTPError)
-						: new InternalServerError(err.message, {cause: err});
-
-					// Log at appropriate level: warn for 4xx (client errors), error for 5xx (server errors)
-					if (httpError.status >= 500) {
-						logger.error("Request error: {error}", {error: err});
-					} else {
-						logger.warn("Request error: {status} {error}", {
-							status: httpError.status,
-							error: err,
-						});
-					}
-
-					const isDev = import.meta.env?.MODE !== "production";
-					return httpError.toResponse(isDev);
+					return handleError(error);
 				}
+			},
+			websocket: {
+				open(ws) {
+					const {connectionID} = ws.data;
+					wsConnections.set(connectionID, ws);
+				},
+				message(ws, message) {
+					const {connectionID} = ws.data;
+					if (pool) {
+						const data =
+							typeof message === "string"
+								? message
+								: (message.buffer as ArrayBuffer);
+						pool.sendWebSocketMessage(connectionID, data);
+					}
+				},
+				close(ws, code, reason) {
+					const {connectionID} = ws.data;
+					if (pool) {
+						pool.sendWebSocketClose(connectionID, code, reason, true);
+					}
+					wsConnections.delete(connectionID);
+				},
 			},
 		});
 
 		// Get the actual port (important when port 0 was requested)
-		// server.port is always defined after Bun.serve() returns
 		const actualPort = server.port as number;
 
 		return {
@@ -318,6 +369,11 @@ export class BunPlatform {
 				});
 			},
 			async close() {
+				// Close all WebSocket connections
+				for (const [id, ws] of wsConnections) {
+					ws.close(1001, "Server shutting down");
+					wsConnections.delete(id);
+				}
 				server.stop();
 			},
 			address: () => ({port: actualPort, host: hostname}),
@@ -341,10 +397,13 @@ export class BunPlatform {
 			);
 		}
 
-		this.#server = this.createServer((request) => pool.handleRequest(request), {
-			port: this.#options.port,
-			host: this.#options.host,
-		});
+		this.#server = this.createServer(
+			async (request) => {
+				const result = await pool.handleRequest(request);
+				return result as Response;
+			},
+			{pool, port: this.#options.port, host: this.#options.host},
+		);
 		await this.#server.listen();
 		return this.#server;
 	}
@@ -386,7 +445,7 @@ export class BunPlatform {
 		const prodWorkerCode = `// Bun Production Worker
 import BunPlatform from "@b9g/platform-bun";
 import {getLogger} from "@logtape/logtape";
-import {configureLogging, initWorkerRuntime, runLifecycle, dispatchRequest, setBroadcastChannelRelay, deliverBroadcastMessage} from "@b9g/platform/runtime";
+import {configureLogging, initWorkerRuntime, runLifecycle, createDirectModePool, setBroadcastChannelRelay, deliverBroadcastMessage} from "@b9g/platform/runtime";
 import {config} from "shovel:config";
 
 await configureLogging(config.logging);
@@ -426,10 +485,14 @@ await runLifecycle(registration, config.lifecycle?.stage);
 
 // Start server (skip in lifecycle-only mode)
 if (!config.lifecycle) {
+	const pool = createDirectModePool(registration, result.clients);
 	const platform = new BunPlatform({port: config.port, host: config.host});
 	server = platform.createServer(
-		(request) => dispatchRequest(registration, request),
-		{reusePort: config.workers > 1},
+		async (request) => {
+			const r = await pool.handleRequest(request);
+			return r;
+		},
+		{pool, reusePort: config.workers > 1},
 	);
 	await server.listen();
 }

--- a/packages/platform-bun/src/index.ts
+++ b/packages/platform-bun/src/index.ts
@@ -394,8 +394,10 @@ export class BunPlatform {
 					if (pool) {
 						if (typeof message === "string") {
 							pool.sendWebSocketMessage(connectionID, message);
+						} else if (message instanceof ArrayBuffer) {
+							pool.sendWebSocketMessage(connectionID, message);
 						} else {
-							// Slice to respect byteOffset/byteLength of the typed array view
+							// Typed array view — slice to respect byteOffset/byteLength
 							const buf = message.buffer.slice(
 								message.byteOffset,
 								message.byteOffset + message.byteLength,

--- a/packages/platform-bun/src/index.ts
+++ b/packages/platform-bun/src/index.ts
@@ -318,7 +318,10 @@ export class BunPlatform {
 			async fetch(request, server) {
 				try {
 					// Check for WebSocket upgrade when pool is available
-					if (pool && request.headers.get("upgrade") === "websocket") {
+					if (
+						pool &&
+						request.headers.get("upgrade")?.toLowerCase() === "websocket"
+					) {
 						const result = await pool.handleRequest(request);
 						if ("upgrade" in result) {
 							server.upgrade(request, {

--- a/packages/platform-bun/src/index.ts
+++ b/packages/platform-bun/src/index.ts
@@ -457,6 +457,12 @@ export class BunPlatform {
 			async (request) => {
 				const result = await pool.handleRequest(request);
 				if ("upgrade" in result) {
+					pool.sendWebSocketClose(
+						result.connectionID,
+						1002,
+						"Not a WebSocket request",
+						false,
+					);
 					return new Response("Upgrade Required", {status: 426});
 				}
 				return result;
@@ -549,7 +555,7 @@ if (!config.lifecycle) {
 	server = platform.createServer(
 		async (request) => {
 			const r = await pool.handleRequest(request);
-			if ("upgrade" in r) return new Response("Upgrade Required", {status: 426});
+			if ("upgrade" in r) { pool.sendWebSocketClose(r.connectionID, 1002, "Not a WebSocket request", false); return new Response("Upgrade Required", {status: 426}); }
 			return r;
 		},
 		{pool, reusePort: config.workers > 1},

--- a/packages/platform-bun/src/index.ts
+++ b/packages/platform-bun/src/index.ts
@@ -276,19 +276,42 @@ export class BunPlatform {
 		const reusePort = options.reusePort ?? false;
 		const pool = options.pool;
 		const wsConnections = new Map<string, any>();
+		const wsPendingMessages = new Map<
+			string,
+			Array<
+				| {type: "send"; data: string | ArrayBuffer}
+				| {type: "close"; code?: number; reason?: string}
+			>
+		>();
 
 		// Wire up pool callbacks for outbound WebSocket I/O
 		if (pool) {
 			pool.setWebSocketHandlers({
 				send(connectionID: string, data: string | ArrayBuffer) {
 					const ws = wsConnections.get(connectionID);
-					if (ws) ws.send(data);
+					if (ws) {
+						ws.send(data);
+					} else {
+						let buf = wsPendingMessages.get(connectionID);
+						if (!buf) {
+							buf = [];
+							wsPendingMessages.set(connectionID, buf);
+						}
+						buf.push({type: "send", data});
+					}
 				},
 				close(connectionID: string, code?: number, reason?: string) {
 					const ws = wsConnections.get(connectionID);
 					if (ws) {
 						ws.close(code ?? 1000, reason ?? "");
 						wsConnections.delete(connectionID);
+					} else {
+						let buf = wsPendingMessages.get(connectionID);
+						if (!buf) {
+							buf = [];
+							wsPendingMessages.set(connectionID, buf);
+						}
+						buf.push({type: "close", code, reason});
 					}
 				},
 			});
@@ -353,6 +376,18 @@ export class BunPlatform {
 				open(ws) {
 					const {connectionID} = ws.data;
 					wsConnections.set(connectionID, ws);
+					// Flush any messages buffered before the socket opened
+					const pending = wsPendingMessages.get(connectionID);
+					if (pending) {
+						wsPendingMessages.delete(connectionID);
+						for (const msg of pending) {
+							if (msg.type === "send") {
+								ws.send(msg.data);
+							} else if (msg.type === "close") {
+								ws.close(msg.code ?? 1000, msg.reason ?? "");
+							}
+						}
+					}
 				},
 				message(ws, message) {
 					const {connectionID} = ws.data;

--- a/packages/platform-bun/src/index.ts
+++ b/packages/platform-bun/src/index.ts
@@ -342,11 +342,16 @@ export class BunPlatform {
 				message(ws, message) {
 					const {connectionID} = ws.data;
 					if (pool) {
-						const data =
-							typeof message === "string"
-								? message
-								: (message.buffer as ArrayBuffer);
-						pool.sendWebSocketMessage(connectionID, data);
+						if (typeof message === "string") {
+							pool.sendWebSocketMessage(connectionID, message);
+						} else {
+							// Slice to respect byteOffset/byteLength of the typed array view
+							const buf = message.buffer.slice(
+								message.byteOffset,
+								message.byteOffset + message.byteLength,
+							);
+							pool.sendWebSocketMessage(connectionID, buf);
+						}
 					}
 				},
 				close(ws, code, reason) {

--- a/packages/platform-bun/src/platform.ts
+++ b/packages/platform-bun/src/platform.ts
@@ -113,6 +113,7 @@ if (!config.lifecycle) {
 	server = platform.createServer(
 		async (request) => {
 			const r = await pool.handleRequest(request);
+			if ("upgrade" in r) return new Response("Upgrade Required", {status: 426});
 			return r;
 		},
 		{pool, reusePort: config.workers > 1},

--- a/packages/platform-bun/src/platform.ts
+++ b/packages/platform-bun/src/platform.ts
@@ -75,7 +75,7 @@ startWorkerMessageLoop({registration, databases});
 	const prodWorkerCode = `// Bun Production Worker
 import BunPlatform from "@b9g/platform-bun";
 import {getLogger} from "@logtape/logtape";
-import {configureLogging, initWorkerRuntime, runLifecycle, dispatchRequest} from "@b9g/platform/runtime";
+import {configureLogging, initWorkerRuntime, runLifecycle, createDirectModePool} from "@b9g/platform/runtime";
 import {config} from "shovel:config";
 
 await configureLogging(config.logging);
@@ -108,10 +108,14 @@ await runLifecycle(registration, config.lifecycle?.stage);
 
 // Start server (skip in lifecycle-only mode)
 if (!config.lifecycle) {
+	const pool = createDirectModePool(registration, result.clients);
 	const platform = new BunPlatform({port: config.port, host: config.host});
 	server = platform.createServer(
-		(request) => dispatchRequest(registration, request),
-		{reusePort: config.workers > 1},
+		async (request) => {
+			const r = await pool.handleRequest(request);
+			return r;
+		},
+		{pool, reusePort: config.workers > 1},
 	);
 	await server.listen();
 }

--- a/packages/platform-bun/src/platform.ts
+++ b/packages/platform-bun/src/platform.ts
@@ -113,7 +113,7 @@ if (!config.lifecycle) {
 	server = platform.createServer(
 		async (request) => {
 			const r = await pool.handleRequest(request);
-			if ("upgrade" in r) return new Response("Upgrade Required", {status: 426});
+			if ("upgrade" in r) { pool.sendWebSocketClose(r.connectionID, 1002, "Not a WebSocket request", false); return new Response("Upgrade Required", {status: 426}); }
 			return r;
 		},
 		{pool, reusePort: config.workers > 1},

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -87,6 +87,14 @@
       "types": "./dist/src/platform.d.ts",
       "import": "./dist/src/platform.js"
     },
+    "./websocket-do": {
+      "types": "./dist/src/websocket-do.d.ts",
+      "import": "./dist/src/websocket-do.js"
+    },
+    "./websocket-do.js": {
+      "types": "./dist/src/websocket-do.d.ts",
+      "import": "./dist/src/websocket-do.js"
+    },
     "./pubsub": {
       "types": "./dist/src/pubsub.d.ts",
       "import": "./dist/src/pubsub.js"

--- a/packages/platform-cloudflare/src/index.ts
+++ b/packages/platform-cloudflare/src/index.ts
@@ -352,6 +352,7 @@ export class CloudflarePlatform {
 		const serverCode = `// Cloudflare Worker Entry
 import { config } from "shovel:config";
 import { initializeRuntime, createFetchHandler } from "@b9g/platform-cloudflare/runtime";
+import { ShovelWebSocketDO } from "@b9g/platform-cloudflare/websocket-do";
 
 // Initialize runtime first (installs ServiceWorker globals like addEventListener)
 const registration = await initializeRuntime(config);
@@ -362,6 +363,10 @@ await import(${safePath});
 
 // Lifecycle deferred to first request (workerd doesn't allow setTimeout in global scope)
 export default { fetch: createFetchHandler(registration) };
+
+// Export Durable Object class for WebSocket hibernation support.
+// Add to wrangler.toml: [[durable_objects.bindings]] name = "SHOVEL_WS" class_name = "ShovelWebSocketDO"
+export { ShovelWebSocketDO };
 `;
 
 		return {

--- a/packages/platform-cloudflare/src/index.ts
+++ b/packages/platform-cloudflare/src/index.ts
@@ -356,7 +356,6 @@ export class CloudflarePlatform {
 		const serverCode = `// Cloudflare Worker Entry
 import { config } from "shovel:config";
 import { initializeRuntime, createFetchHandler } from "@b9g/platform-cloudflare/runtime";
-import { ShovelWebSocketDO } from "@b9g/platform-cloudflare/websocket-do";
 
 // Initialize runtime first (installs ServiceWorker globals like addEventListener)
 const registration = await initializeRuntime(config);
@@ -367,10 +366,6 @@ await import(${safePath});
 
 // Lifecycle deferred to first request (workerd doesn't allow setTimeout in global scope)
 export default { fetch: createFetchHandler(registration) };
-
-// Export Durable Object class for WebSocket hibernation support.
-// Add to wrangler.toml: [[durable_objects.bindings]] name = "SHOVEL_WS" class_name = "ShovelWebSocketDO"
-export { ShovelWebSocketDO };
 `;
 
 		return {

--- a/packages/platform-cloudflare/src/index.ts
+++ b/packages/platform-cloudflare/src/index.ts
@@ -304,6 +304,10 @@ export class CloudflarePlatform {
 					body: request.body,
 					duplex: request.body ? "half" : undefined,
 				});
+				// Preserve webSocket property for WebSocket upgrade responses
+				if ((cfResponse as any).webSocket) {
+					return cfResponse as Response;
+				}
 				return new Response(cfResponse.body as BodyInit | null, {
 					status: cfResponse.status,
 					statusText: cfResponse.statusText,

--- a/packages/platform-cloudflare/src/index.ts
+++ b/packages/platform-cloudflare/src/index.ts
@@ -356,6 +356,7 @@ export class CloudflarePlatform {
 		const serverCode = `// Cloudflare Worker Entry
 import { config } from "shovel:config";
 import { initializeRuntime, createFetchHandler } from "@b9g/platform-cloudflare/runtime";
+import { ShovelWebSocketDO } from "@b9g/platform-cloudflare/websocket-do";
 
 // Initialize runtime first (installs ServiceWorker globals like addEventListener)
 const registration = await initializeRuntime(config);
@@ -366,6 +367,10 @@ await import(${safePath});
 
 // Lifecycle deferred to first request (workerd doesn't allow setTimeout in global scope)
 export default { fetch: createFetchHandler(registration) };
+
+// Durable Object for WebSocket hibernation — auto-configured when
+// SHOVEL_WS binding is present in wrangler.toml
+export { ShovelWebSocketDO };
 `;
 
 		return {

--- a/packages/platform-cloudflare/src/platform.ts
+++ b/packages/platform-cloudflare/src/platform.ts
@@ -43,6 +43,7 @@ export function getEntryPoints(
 	const workerCode = `// Cloudflare Worker Entry
 import { config } from "shovel:config";
 import { initializeRuntime, createFetchHandler } from "@b9g/platform-cloudflare/runtime";
+import { ShovelWebSocketDO } from "@b9g/platform-cloudflare/websocket-do";
 
 // Initialize runtime (installs ServiceWorker globals)
 const registration = await initializeRuntime(config);
@@ -52,6 +53,10 @@ await import(${safePath});
 
 // Lifecycle deferred to first request (workerd restriction)
 export default { fetch: createFetchHandler(registration) };
+
+// Durable Object for WebSocket hibernation support
+// Add to wrangler.toml: [[durable_objects.bindings]] name = "SHOVEL_WS" class_name = "ShovelWebSocketDO"
+export { ShovelWebSocketDO };
 `;
 
 	return {worker: workerCode};

--- a/packages/platform-cloudflare/src/platform.ts
+++ b/packages/platform-cloudflare/src/platform.ts
@@ -43,7 +43,6 @@ export function getEntryPoints(
 	const workerCode = `// Cloudflare Worker Entry
 import { config } from "shovel:config";
 import { initializeRuntime, createFetchHandler } from "@b9g/platform-cloudflare/runtime";
-import { ShovelWebSocketDO } from "@b9g/platform-cloudflare/websocket-do";
 
 // Initialize runtime (installs ServiceWorker globals)
 const registration = await initializeRuntime(config);
@@ -53,10 +52,6 @@ await import(${safePath});
 
 // Lifecycle deferred to first request (workerd restriction)
 export default { fetch: createFetchHandler(registration) };
-
-// Durable Object for WebSocket hibernation support
-// Add to wrangler.toml: [[durable_objects.bindings]] name = "SHOVEL_WS" class_name = "ShovelWebSocketDO"
-export { ShovelWebSocketDO };
 `;
 
 	return {worker: workerCode};

--- a/packages/platform-cloudflare/src/platform.ts
+++ b/packages/platform-cloudflare/src/platform.ts
@@ -43,6 +43,7 @@ export function getEntryPoints(
 	const workerCode = `// Cloudflare Worker Entry
 import { config } from "shovel:config";
 import { initializeRuntime, createFetchHandler } from "@b9g/platform-cloudflare/runtime";
+import { ShovelWebSocketDO } from "@b9g/platform-cloudflare/websocket-do";
 
 // Initialize runtime (installs ServiceWorker globals)
 const registration = await initializeRuntime(config);
@@ -52,6 +53,8 @@ await import(${safePath});
 
 // Lifecycle deferred to first request (workerd restriction)
 export default { fetch: createFetchHandler(registration) };
+
+export { ShovelWebSocketDO };
 `;
 
 	return {worker: workerCode};

--- a/packages/platform-cloudflare/src/runtime.ts
+++ b/packages/platform-cloudflare/src/runtime.ts
@@ -172,9 +172,8 @@ export function createFetchHandler(
 			envRecord.SHOVEL_WS
 		) {
 			const ns = envRecord.SHOVEL_WS as DurableObjectNamespace;
-			// Each connection gets its own DO for scalability — hibernation
-			// keeps idle DOs cheap, and this avoids single-object bottlenecks
-			const id = ns.newUniqueId();
+			// Single shared DO so self.clients.matchAll() sees all connections
+			const id = ns.idFromName("shovel-ws");
 			const stub = ns.get(id);
 			return stub.fetch(request);
 		}

--- a/packages/platform-cloudflare/src/runtime.ts
+++ b/packages/platform-cloudflare/src/runtime.ts
@@ -164,13 +164,15 @@ export function createFetchHandler(
 		}
 
 		// Route WebSocket upgrades to Durable Object for hibernation support
-		if (
-			request.headers.get("upgrade")?.toLowerCase() === "websocket" &&
-			envRecord.SHOVEL_WS
-		) {
+		if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
+			if (!envRecord.SHOVEL_WS) {
+				return new Response(
+					"WebSocket support requires SHOVEL_WS Durable Object binding. " +
+						'Add to wrangler.toml: [[durable_objects.bindings]] name = "SHOVEL_WS" class_name = "ShovelWebSocketDO"',
+					{status: 501},
+				);
+			}
 			const ns = envRecord.SHOVEL_WS as DurableObjectNamespace;
-			// Use a consistent ID so all connections share the same DO instance
-			// (users can customize routing by overriding this handler)
 			const id = ns.idFromName("default");
 			const stub = ns.get(id);
 			return stub.fetch(request);

--- a/packages/platform-cloudflare/src/runtime.ts
+++ b/packages/platform-cloudflare/src/runtime.ts
@@ -169,21 +169,6 @@ export function createFetchHandler(
 			bcBackendConfigured = true;
 		}
 
-		// Route WebSocket upgrades to Durable Object for hibernation support
-		// Only intercept when SHOVEL_WS binding is configured — otherwise
-		// let the request reach user code (for manual WebSocketPair usage)
-		if (
-			request.headers.get("upgrade")?.toLowerCase() === "websocket" &&
-			envRecord.SHOVEL_WS
-		) {
-			const ns = envRecord.SHOVEL_WS as DurableObjectNamespace;
-			// Each connection gets its own DO for scalability — hibernation
-			// keeps idle DOs cheap, and this avoids single-object bottlenecks
-			const id = ns.newUniqueId();
-			const stub = ns.get(id);
-			return stub.fetch(request);
-		}
-
 		// Build relay for WebSocketPair fallback (non-hibernation)
 		// Buffers until the real socket is wired up, same as Node/Bun
 		const pendingMessages: Array<

--- a/packages/platform-cloudflare/src/runtime.ts
+++ b/packages/platform-cloudflare/src/runtime.ts
@@ -20,7 +20,6 @@ import {
 	type ShovelConfig,
 } from "@b9g/platform/runtime";
 
-// runLifecycle is used internally by createFetchHandler (not re-exported)
 import {CustomCacheStorage} from "@b9g/cache";
 import {CustomDirectoryStorage} from "@b9g/filesystem";
 import {getLogger} from "@logtape/logtape";
@@ -164,6 +163,19 @@ export function createFetchHandler(
 			bcBackendConfigured = true;
 		}
 
+		// Route WebSocket upgrades to Durable Object for hibernation support
+		if (
+			request.headers.get("upgrade")?.toLowerCase() === "websocket" &&
+			envRecord.SHOVEL_WS
+		) {
+			const ns = envRecord.SHOVEL_WS as DurableObjectNamespace;
+			// Use a consistent ID so all connections share the same DO instance
+			// (users can customize routing by overriding this handler)
+			const id = ns.idFromName("default");
+			const stub = ns.get(id);
+			return stub.fetch(request);
+		}
+
 		// Create CloudflareFetchEvent with env and waitUntil hook
 		const event = new CloudflareFetchEvent(request, {
 			env: envRecord,
@@ -175,4 +187,13 @@ export function createFetchHandler(
 			dispatchRequest(registration, event),
 		);
 	};
+}
+
+/**
+ * Get the module-level registration singleton.
+ * Used by ShovelWebSocketDO after hibernation wake-up.
+ * @internal
+ */
+export function _getRegistration(): ShovelServiceWorkerRegistration | null {
+	return _registration;
 }

--- a/packages/platform-cloudflare/src/runtime.ts
+++ b/packages/platform-cloudflare/src/runtime.ts
@@ -164,14 +164,12 @@ export function createFetchHandler(
 		}
 
 		// Route WebSocket upgrades to Durable Object for hibernation support
-		if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
-			if (!envRecord.SHOVEL_WS) {
-				return new Response(
-					"WebSocket support requires SHOVEL_WS Durable Object binding. " +
-						'Add to wrangler.toml: [[durable_objects.bindings]] name = "SHOVEL_WS" class_name = "ShovelWebSocketDO"',
-					{status: 501},
-				);
-			}
+		// Only intercept when SHOVEL_WS binding is configured — otherwise
+		// let the request reach user code (for manual WebSocketPair usage)
+		if (
+			request.headers.get("upgrade")?.toLowerCase() === "websocket" &&
+			envRecord.SHOVEL_WS
+		) {
 			const ns = envRecord.SHOVEL_WS as DurableObjectNamespace;
 			const id = ns.idFromName("default");
 			const stub = ns.get(id);

--- a/packages/platform-cloudflare/src/runtime.ts
+++ b/packages/platform-cloudflare/src/runtime.ts
@@ -15,7 +15,10 @@ import {
 	createCacheFactory,
 	createDirectoryFactory,
 	runLifecycle,
-	dispatchRequest,
+	dispatchFetchEvent,
+	kGetUpgradeResult,
+	dispatchWebSocketMessage,
+	dispatchWebSocketClose,
 	setBroadcastChannelBackend,
 	type ShovelConfig,
 } from "@b9g/platform/runtime";
@@ -185,9 +188,53 @@ export function createFetchHandler(
 		});
 
 		// Run within envStorage for directory factory access
-		return envStorage.run(envRecord, () =>
-			dispatchRequest(registration, event),
-		);
+		return envStorage.run(envRecord, async () => {
+			const {response, event: fetchEvent} = await dispatchFetchEvent(
+				registration,
+				event,
+			);
+
+			// Handle WebSocket upgrade without DO (non-hibernation fallback)
+			const upgrade = fetchEvent[kGetUpgradeResult]?.();
+			if (upgrade) {
+				const pair = new WebSocketPair();
+				const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+				(server as any).accept();
+
+				server.addEventListener("message", (msg: MessageEvent) => {
+					dispatchWebSocketMessage(
+						registration,
+						upgrade.client,
+						msg.data,
+					).catch(() => {});
+				});
+				server.addEventListener("close", (evt: CloseEvent) => {
+					dispatchWebSocketClose(
+						registration,
+						upgrade.client,
+						evt.code,
+						evt.reason,
+						evt.wasClean,
+					).catch(() => {});
+				});
+
+				upgrade.client.setRelay({
+					send(_id: string, data: string | ArrayBuffer) {
+						server.send(data);
+					},
+					close(_id: string, code?: number, reason?: string) {
+						server.close(code ?? 1000, reason ?? "");
+					},
+				});
+
+				return new Response(null, {
+					status: 101,
+					webSocket: client,
+				} as any);
+			}
+
+			return response!;
+		});
 	};
 }
 

--- a/packages/platform-cloudflare/src/runtime.ts
+++ b/packages/platform-cloudflare/src/runtime.ts
@@ -15,11 +15,7 @@ import {
 	createCacheFactory,
 	createDirectoryFactory,
 	runLifecycle,
-	dispatchFetchEvent,
-	kGetUpgradeResult,
-	dispatchWebSocketMessage,
-	dispatchWebSocketClose,
-	ShovelClients,
+	dispatchRequest,
 	setBroadcastChannelBackend,
 	type ShovelConfig,
 } from "@b9g/platform/runtime";
@@ -29,8 +25,6 @@ import {CustomCacheStorage} from "@b9g/cache";
 import {CustomDirectoryStorage} from "@b9g/filesystem";
 import {getLogger} from "@logtape/logtape";
 import {envStorage} from "./variables.js";
-
-const logger = getLogger(["shovel", "platform"]);
 
 export type {ShovelConfig};
 
@@ -147,29 +141,6 @@ export function createFetchHandler(
 	let lifecyclePromise: Promise<void> | null = null;
 	let bcBackendConfigured = false;
 
-	// Get the ShovelClients instance for WebSocket client registration
-	const shovelClients =
-		typeof self !== "undefined" &&
-		(self as any).clients instanceof ShovelClients
-			? ((self as any).clients as ShovelClients)
-			: null;
-
-	// Per-connection dispatch queue to preserve message ordering
-	const dispatchQueues = new Map<string, Promise<void>>();
-
-	// Relay for outbound WebSocket messages (set per-upgrade, closed over by the event)
-	// Each connection gets its own relay bound to its server socket
-	function createRelay(server: WebSocket) {
-		return {
-			send(_id: string, data: string | ArrayBuffer) {
-				server.send(data);
-			},
-			close(_id: string, code?: number, reason?: string) {
-				server.close(code ?? 1000, reason ?? "");
-			},
-		};
-	}
-
 	return async (
 		request: Request,
 		env: unknown,
@@ -193,85 +164,15 @@ export function createFetchHandler(
 			bcBackendConfigured = true;
 		}
 
-		// Run within envStorage for directory factory access
-		return envStorage.run(envRecord, async () => {
-			// Create WebSocketPair eagerly so we can pass the relay into the event.
-			// The relay lets upgradeWebSocket() return a client with working send/close.
-			const pair = new WebSocketPair();
-			const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
-			const relay = createRelay(server);
-
-			// Create CloudflareFetchEvent with env, waitUntil, and WebSocket relay
-			const cfEvent = new CloudflareFetchEvent(request, {
-				env: envRecord,
-				platformWaitUntil: (promise: Promise<unknown>) =>
-					ctx.waitUntil(promise),
-				wsRelay: relay,
-			});
-
-			const {response, event: fetchEvent} = await dispatchFetchEvent(
-				registration,
-				cfEvent,
-			);
-
-			// WebSocket upgrade — wire up the WebSocketPair
-			const upgrade = fetchEvent[kGetUpgradeResult]?.();
-			if (upgrade) {
-				const connectionID = upgrade.client.id;
-
-				// Register with self.clients so clients.get()/matchAll() work
-				shovelClients?.registerWebSocketClient(upgrade.client);
-
-				// Accept the server side to start receiving messages
-				(server as any).accept();
-
-				// Wire incoming messages with ordered dispatch
-				server.addEventListener("message", (msg: MessageEvent) => {
-					const prev = dispatchQueues.get(connectionID) ?? Promise.resolve();
-					const next = prev
-						.then(() =>
-							dispatchWebSocketMessage(registration, upgrade.client, msg.data),
-						)
-						.catch((err) => {
-							logger.error("WebSocket message dispatch failed: {error}", {
-								error: err,
-							});
-						});
-					dispatchQueues.set(connectionID, next);
-				});
-
-				// Wire close with ordered dispatch
-				server.addEventListener("close", (evt: CloseEvent) => {
-					shovelClients?.removeWebSocketClient(connectionID);
-					const prev = dispatchQueues.get(connectionID) ?? Promise.resolve();
-					prev
-						.then(() =>
-							dispatchWebSocketClose(
-								registration,
-								upgrade.client,
-								evt.code,
-								evt.reason,
-								evt.wasClean,
-							),
-						)
-						.catch((err) => {
-							logger.error("WebSocket close dispatch failed: {error}", {
-								error: err,
-							});
-						})
-						.finally(() => {
-							dispatchQueues.delete(connectionID);
-						});
-				});
-
-				// Return the WebSocket upgrade response (Cloudflare allows status 101)
-				return new Response(null, {
-					status: 101,
-					webSocket: client,
-				} as any);
-			}
-
-			return response!;
+		// Create CloudflareFetchEvent with env and waitUntil hook
+		const event = new CloudflareFetchEvent(request, {
+			env: envRecord,
+			platformWaitUntil: (promise) => ctx.waitUntil(promise),
 		});
+
+		// Run within envStorage for directory factory access
+		return envStorage.run(envRecord, () =>
+			dispatchRequest(registration, event),
+		);
 	};
 }

--- a/packages/platform-cloudflare/src/runtime.ts
+++ b/packages/platform-cloudflare/src/runtime.ts
@@ -171,7 +171,9 @@ export function createFetchHandler(
 			envRecord.SHOVEL_WS
 		) {
 			const ns = envRecord.SHOVEL_WS as DurableObjectNamespace;
-			const id = ns.idFromName("default");
+			// Each connection gets its own DO for scalability — hibernation
+			// keeps idle DOs cheap, and this avoids single-object bottlenecks
+			const id = ns.newUniqueId();
 			const stub = ns.get(id);
 			return stub.fetch(request);
 		}

--- a/packages/platform-cloudflare/src/runtime.ts
+++ b/packages/platform-cloudflare/src/runtime.ts
@@ -169,6 +169,21 @@ export function createFetchHandler(
 			bcBackendConfigured = true;
 		}
 
+		// Route WebSocket upgrades to Durable Object for hibernation support
+		// Only intercept when SHOVEL_WS binding is configured — otherwise
+		// let the request reach user code (for manual WebSocketPair usage)
+		if (
+			request.headers.get("upgrade")?.toLowerCase() === "websocket" &&
+			envRecord.SHOVEL_WS
+		) {
+			const ns = envRecord.SHOVEL_WS as DurableObjectNamespace;
+			// Each connection gets its own DO for scalability — hibernation
+			// keeps idle DOs cheap, and this avoids single-object bottlenecks
+			const id = ns.newUniqueId();
+			const stub = ns.get(id);
+			return stub.fetch(request);
+		}
+
 		// Build relay for WebSocketPair fallback (non-hibernation)
 		// Buffers until the real socket is wired up, same as Node/Bun
 		const pendingMessages: Array<

--- a/packages/platform-cloudflare/src/runtime.ts
+++ b/packages/platform-cloudflare/src/runtime.ts
@@ -19,6 +19,7 @@ import {
 	kGetUpgradeResult,
 	dispatchWebSocketMessage,
 	dispatchWebSocketClose,
+	ShovelClients,
 	setBroadcastChannelBackend,
 	type ShovelConfig,
 } from "@b9g/platform/runtime";
@@ -139,6 +140,8 @@ export function createFetchHandler(
 	env: unknown,
 	ctx: ExecutionContext,
 ) => Promise<Response> {
+	const logger = getLogger(["shovel", "platform"]);
+
 	// Defer lifecycle to first request (workerd restriction on setTimeout in global scope)
 	let lifecyclePromise: Promise<void> | null = null;
 	let bcBackendConfigured = false;
@@ -181,14 +184,36 @@ export function createFetchHandler(
 			return stub.fetch(request);
 		}
 
-		// Create CloudflareFetchEvent with env and waitUntil hook
+		// Build relay for WebSocketPair fallback (non-hibernation)
+		// Buffers until the real socket is wired up, same as Node/Bun
+		const pendingMessages: Array<
+			| {type: "send"; data: string | ArrayBuffer}
+			| {type: "close"; code?: number; reason?: string}
+		> = [];
+		const fallbackRelay = {
+			send(_id: string, data: string | ArrayBuffer) {
+				pendingMessages.push({type: "send", data});
+			},
+			close(_id: string, code?: number, reason?: string) {
+				pendingMessages.push({type: "close", code, reason});
+			},
+		};
+
+		// Create CloudflareFetchEvent with env, waitUntil, and relay
 		const event = new CloudflareFetchEvent(request, {
 			env: envRecord,
-			platformWaitUntil: (promise) => ctx.waitUntil(promise),
+			platformWaitUntil: (promise: Promise<unknown>) => ctx.waitUntil(promise),
+			wsRelay: fallbackRelay,
 		});
 
 		// Run within envStorage for directory factory access
 		return envStorage.run(envRecord, async () => {
+			const shovelClients =
+				typeof self !== "undefined" &&
+				(self as any).clients instanceof ShovelClients
+					? ((self as any).clients as ShovelClients)
+					: null;
+
 			const {response, event: fetchEvent} = await dispatchFetchEvent(
 				registration,
 				event,
@@ -201,23 +226,13 @@ export function createFetchHandler(
 				const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
 				(server as any).accept();
 
-				server.addEventListener("message", (msg: MessageEvent) => {
-					dispatchWebSocketMessage(
-						registration,
-						upgrade.client,
-						msg.data,
-					).catch(() => {});
-				});
-				server.addEventListener("close", (evt: CloseEvent) => {
-					dispatchWebSocketClose(
-						registration,
-						upgrade.client,
-						evt.code,
-						evt.reason,
-						evt.wasClean,
-					).catch(() => {});
-				});
+				const connectionID = upgrade.client.id;
+				const dispatchQueues = new Map<string, Promise<void>>();
 
+				// Register with self.clients
+				shovelClients?.registerWebSocketClient(upgrade.client);
+
+				// Bind live relay
 				upgrade.client.setRelay({
 					send(_id: string, data: string | ArrayBuffer) {
 						server.send(data);
@@ -225,6 +240,52 @@ export function createFetchHandler(
 					close(_id: string, code?: number, reason?: string) {
 						server.close(code ?? 1000, reason ?? "");
 					},
+				});
+
+				// Flush buffered messages
+				for (const msg of pendingMessages) {
+					if (msg.type === "send") {
+						server.send(msg.data);
+					} else {
+						server.close(msg.code ?? 1000, msg.reason ?? "");
+					}
+				}
+
+				// Ordered dispatch per connection
+				server.addEventListener("message", (msg: MessageEvent) => {
+					const prev = dispatchQueues.get(connectionID) ?? Promise.resolve();
+					const next = prev
+						.then(() =>
+							dispatchWebSocketMessage(registration, upgrade.client, msg.data),
+						)
+						.catch((err) => {
+							logger.error("WebSocket message dispatch failed: {error}", {
+								error: err,
+							});
+						});
+					dispatchQueues.set(connectionID, next);
+				});
+				server.addEventListener("close", (evt: CloseEvent) => {
+					const prev = dispatchQueues.get(connectionID) ?? Promise.resolve();
+					prev
+						.then(() =>
+							dispatchWebSocketClose(
+								registration,
+								upgrade.client,
+								evt.code,
+								evt.reason,
+								evt.wasClean,
+							),
+						)
+						.catch((err) => {
+							logger.error("WebSocket close dispatch failed: {error}", {
+								error: err,
+							});
+						})
+						.finally(() => {
+							shovelClients?.removeWebSocketClient(connectionID);
+							dispatchQueues.delete(connectionID);
+						});
 				});
 
 				return new Response(null, {

--- a/packages/platform-cloudflare/src/runtime.ts
+++ b/packages/platform-cloudflare/src/runtime.ts
@@ -15,7 +15,8 @@ import {
 	createCacheFactory,
 	createDirectoryFactory,
 	runLifecycle,
-	dispatchRequest,
+	dispatchFetchEvent,
+	kGetUpgradeResult,
 	setBroadcastChannelBackend,
 	type ShovelConfig,
 } from "@b9g/platform/runtime";
@@ -185,9 +186,22 @@ export function createFetchHandler(
 		});
 
 		// Run within envStorage for directory factory access
-		return envStorage.run(envRecord, () =>
-			dispatchRequest(registration, event),
-		);
+		return envStorage.run(envRecord, async () => {
+			const {response, event: fetchEvent} = await dispatchFetchEvent(
+				registration,
+				event,
+			);
+
+			// If user called upgradeWebSocket() without SHOVEL_WS binding, give a clear error
+			if (fetchEvent[kGetUpgradeResult]?.()) {
+				return new Response(
+					"WebSocket upgrade requires SHOVEL_WS Durable Object binding in wrangler.toml",
+					{status: 426},
+				);
+			}
+
+			return response!;
+		});
 	};
 }
 

--- a/packages/platform-cloudflare/src/runtime.ts
+++ b/packages/platform-cloudflare/src/runtime.ts
@@ -19,6 +19,7 @@ import {
 	kGetUpgradeResult,
 	dispatchWebSocketMessage,
 	dispatchWebSocketClose,
+	ShovelClients,
 	setBroadcastChannelBackend,
 	type ShovelConfig,
 } from "@b9g/platform/runtime";
@@ -146,6 +147,29 @@ export function createFetchHandler(
 	let lifecyclePromise: Promise<void> | null = null;
 	let bcBackendConfigured = false;
 
+	// Get the ShovelClients instance for WebSocket client registration
+	const shovelClients =
+		typeof self !== "undefined" &&
+		(self as any).clients instanceof ShovelClients
+			? ((self as any).clients as ShovelClients)
+			: null;
+
+	// Per-connection dispatch queue to preserve message ordering
+	const dispatchQueues = new Map<string, Promise<void>>();
+
+	// Relay for outbound WebSocket messages (set per-upgrade, closed over by the event)
+	// Each connection gets its own relay bound to its server socket
+	function createRelay(server: WebSocket) {
+		return {
+			send(_id: string, data: string | ArrayBuffer) {
+				server.send(data);
+			},
+			close(_id: string, code?: number, reason?: string) {
+				server.close(code ?? 1000, reason ?? "");
+			},
+		};
+	}
+
 	return async (
 		request: Request,
 		env: unknown,
@@ -169,64 +193,75 @@ export function createFetchHandler(
 			bcBackendConfigured = true;
 		}
 
-		// Create CloudflareFetchEvent with env and waitUntil hook
-		const cfEvent = new CloudflareFetchEvent(request, {
-			env: envRecord,
-			platformWaitUntil: (promise: Promise<unknown>) => ctx.waitUntil(promise),
-		});
-
 		// Run within envStorage for directory factory access
 		return envStorage.run(envRecord, async () => {
+			// Create WebSocketPair eagerly so we can pass the relay into the event.
+			// The relay lets upgradeWebSocket() return a client with working send/close.
+			const pair = new WebSocketPair();
+			const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+			const relay = createRelay(server);
+
+			// Create CloudflareFetchEvent with env, waitUntil, and WebSocket relay
+			const cfEvent = new CloudflareFetchEvent(request, {
+				env: envRecord,
+				platformWaitUntil: (promise: Promise<unknown>) =>
+					ctx.waitUntil(promise),
+				wsRelay: relay,
+			});
+
 			const {response, event: fetchEvent} = await dispatchFetchEvent(
 				registration,
 				cfEvent,
 			);
 
-			// WebSocket upgrade — use Cloudflare's WebSocketPair
+			// WebSocket upgrade — wire up the WebSocketPair
 			const upgrade = fetchEvent[kGetUpgradeResult]?.();
 			if (upgrade) {
-				const pair = new WebSocketPair();
-				const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+				const connectionID = upgrade.client.id;
+
+				// Register with self.clients so clients.get()/matchAll() work
+				shovelClients?.registerWebSocketClient(upgrade.client);
 
 				// Accept the server side to start receiving messages
 				(server as any).accept();
 
-				// Wire incoming messages → dispatch websocketmessage events
+				// Wire incoming messages with ordered dispatch
 				server.addEventListener("message", (msg: MessageEvent) => {
-					dispatchWebSocketMessage(
-						registration,
-						upgrade.client,
-						msg.data,
-					).catch((err) => {
-						logger.error("WebSocket message dispatch failed: {error}", {
-							error: err,
+					const prev = dispatchQueues.get(connectionID) ?? Promise.resolve();
+					const next = prev
+						.then(() =>
+							dispatchWebSocketMessage(registration, upgrade.client, msg.data),
+						)
+						.catch((err) => {
+							logger.error("WebSocket message dispatch failed: {error}", {
+								error: err,
+							});
 						});
-					});
+					dispatchQueues.set(connectionID, next);
 				});
 
-				// Wire close → dispatch websocketclose events
+				// Wire close with ordered dispatch
 				server.addEventListener("close", (evt: CloseEvent) => {
-					dispatchWebSocketClose(
-						registration,
-						upgrade.client,
-						evt.code,
-						evt.reason,
-						evt.wasClean,
-					).catch((err) => {
-						logger.error("WebSocket close dispatch failed: {error}", {
-							error: err,
+					shovelClients?.removeWebSocketClient(connectionID);
+					const prev = dispatchQueues.get(connectionID) ?? Promise.resolve();
+					prev
+						.then(() =>
+							dispatchWebSocketClose(
+								registration,
+								upgrade.client,
+								evt.code,
+								evt.reason,
+								evt.wasClean,
+							),
+						)
+						.catch((err) => {
+							logger.error("WebSocket close dispatch failed: {error}", {
+								error: err,
+							});
+						})
+						.finally(() => {
+							dispatchQueues.delete(connectionID);
 						});
-					});
-				});
-
-				// Wire outbound: ShovelWebSocketClient.send/close → real socket
-				upgrade.client.setRelay({
-					send(_id: string, data: string | ArrayBuffer) {
-						server.send(data);
-					},
-					close(_id: string, code?: number, reason?: string) {
-						server.close(code ?? 1000, reason ?? "");
-					},
 				});
 
 				// Return the WebSocket upgrade response (Cloudflare allows status 101)

--- a/packages/platform-cloudflare/src/runtime.ts
+++ b/packages/platform-cloudflare/src/runtime.ts
@@ -15,7 +15,10 @@ import {
 	createCacheFactory,
 	createDirectoryFactory,
 	runLifecycle,
-	dispatchRequest,
+	dispatchFetchEvent,
+	kGetUpgradeResult,
+	dispatchWebSocketMessage,
+	dispatchWebSocketClose,
 	setBroadcastChannelBackend,
 	type ShovelConfig,
 } from "@b9g/platform/runtime";
@@ -25,6 +28,8 @@ import {CustomCacheStorage} from "@b9g/cache";
 import {CustomDirectoryStorage} from "@b9g/filesystem";
 import {getLogger} from "@logtape/logtape";
 import {envStorage} from "./variables.js";
+
+const logger = getLogger(["shovel", "platform"]);
 
 export type {ShovelConfig};
 
@@ -165,14 +170,73 @@ export function createFetchHandler(
 		}
 
 		// Create CloudflareFetchEvent with env and waitUntil hook
-		const event = new CloudflareFetchEvent(request, {
+		const cfEvent = new CloudflareFetchEvent(request, {
 			env: envRecord,
-			platformWaitUntil: (promise) => ctx.waitUntil(promise),
+			platformWaitUntil: (promise: Promise<unknown>) => ctx.waitUntil(promise),
 		});
 
 		// Run within envStorage for directory factory access
-		return envStorage.run(envRecord, () =>
-			dispatchRequest(registration, event),
-		);
+		return envStorage.run(envRecord, async () => {
+			const {response, event: fetchEvent} = await dispatchFetchEvent(
+				registration,
+				cfEvent,
+			);
+
+			// WebSocket upgrade — use Cloudflare's WebSocketPair
+			const upgrade = fetchEvent[kGetUpgradeResult]?.();
+			if (upgrade) {
+				const pair = new WebSocketPair();
+				const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+
+				// Accept the server side to start receiving messages
+				(server as any).accept();
+
+				// Wire incoming messages → dispatch websocketmessage events
+				server.addEventListener("message", (msg: MessageEvent) => {
+					dispatchWebSocketMessage(
+						registration,
+						upgrade.client,
+						msg.data,
+					).catch((err) => {
+						logger.error("WebSocket message dispatch failed: {error}", {
+							error: err,
+						});
+					});
+				});
+
+				// Wire close → dispatch websocketclose events
+				server.addEventListener("close", (evt: CloseEvent) => {
+					dispatchWebSocketClose(
+						registration,
+						upgrade.client,
+						evt.code,
+						evt.reason,
+						evt.wasClean,
+					).catch((err) => {
+						logger.error("WebSocket close dispatch failed: {error}", {
+							error: err,
+						});
+					});
+				});
+
+				// Wire outbound: ShovelWebSocketClient.send/close → real socket
+				upgrade.client.setRelay({
+					send(_id: string, data: string | ArrayBuffer) {
+						server.send(data);
+					},
+					close(_id: string, code?: number, reason?: string) {
+						server.close(code ?? 1000, reason ?? "");
+					},
+				});
+
+				// Return the WebSocket upgrade response (Cloudflare allows status 101)
+				return new Response(null, {
+					status: 101,
+					webSocket: client,
+				} as any);
+			}
+
+			return response!;
+		});
 	};
 }

--- a/packages/platform-cloudflare/src/runtime.ts
+++ b/packages/platform-cloudflare/src/runtime.ts
@@ -15,11 +15,7 @@ import {
 	createCacheFactory,
 	createDirectoryFactory,
 	runLifecycle,
-	dispatchFetchEvent,
-	kGetUpgradeResult,
-	dispatchWebSocketMessage,
-	dispatchWebSocketClose,
-	ShovelClients,
+	dispatchRequest,
 	setBroadcastChannelBackend,
 	type ShovelConfig,
 } from "@b9g/platform/runtime";
@@ -140,8 +136,6 @@ export function createFetchHandler(
 	env: unknown,
 	ctx: ExecutionContext,
 ) => Promise<Response> {
-	const logger = getLogger(["shovel", "platform"]);
-
 	// Defer lifecycle to first request (workerd restriction on setTimeout in global scope)
 	let lifecyclePromise: Promise<void> | null = null;
 	let bcBackendConfigured = false;
@@ -184,118 +178,16 @@ export function createFetchHandler(
 			return stub.fetch(request);
 		}
 
-		// Build relay for WebSocketPair fallback (non-hibernation)
-		// Buffers until the real socket is wired up, same as Node/Bun
-		const pendingMessages: Array<
-			| {type: "send"; data: string | ArrayBuffer}
-			| {type: "close"; code?: number; reason?: string}
-		> = [];
-		const fallbackRelay = {
-			send(_id: string, data: string | ArrayBuffer) {
-				pendingMessages.push({type: "send", data});
-			},
-			close(_id: string, code?: number, reason?: string) {
-				pendingMessages.push({type: "close", code, reason});
-			},
-		};
-
-		// Create CloudflareFetchEvent with env, waitUntil, and relay
+		// Create CloudflareFetchEvent with env and waitUntil hook
 		const event = new CloudflareFetchEvent(request, {
 			env: envRecord,
-			platformWaitUntil: (promise: Promise<unknown>) => ctx.waitUntil(promise),
-			wsRelay: fallbackRelay,
+			platformWaitUntil: (promise) => ctx.waitUntil(promise),
 		});
 
 		// Run within envStorage for directory factory access
-		return envStorage.run(envRecord, async () => {
-			const shovelClients =
-				typeof self !== "undefined" &&
-				(self as any).clients instanceof ShovelClients
-					? ((self as any).clients as ShovelClients)
-					: null;
-
-			const {response, event: fetchEvent} = await dispatchFetchEvent(
-				registration,
-				event,
-			);
-
-			// Handle WebSocket upgrade without DO (non-hibernation fallback)
-			const upgrade = fetchEvent[kGetUpgradeResult]?.();
-			if (upgrade) {
-				const pair = new WebSocketPair();
-				const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
-				(server as any).accept();
-
-				const connectionID = upgrade.client.id;
-				const dispatchQueues = new Map<string, Promise<void>>();
-
-				// Register with self.clients
-				shovelClients?.registerWebSocketClient(upgrade.client);
-
-				// Bind live relay
-				upgrade.client.setRelay({
-					send(_id: string, data: string | ArrayBuffer) {
-						server.send(data);
-					},
-					close(_id: string, code?: number, reason?: string) {
-						server.close(code ?? 1000, reason ?? "");
-					},
-				});
-
-				// Flush buffered messages
-				for (const msg of pendingMessages) {
-					if (msg.type === "send") {
-						server.send(msg.data);
-					} else {
-						server.close(msg.code ?? 1000, msg.reason ?? "");
-					}
-				}
-
-				// Ordered dispatch per connection
-				server.addEventListener("message", (msg: MessageEvent) => {
-					const prev = dispatchQueues.get(connectionID) ?? Promise.resolve();
-					const next = prev
-						.then(() =>
-							dispatchWebSocketMessage(registration, upgrade.client, msg.data),
-						)
-						.catch((err) => {
-							logger.error("WebSocket message dispatch failed: {error}", {
-								error: err,
-							});
-						});
-					dispatchQueues.set(connectionID, next);
-				});
-				server.addEventListener("close", (evt: CloseEvent) => {
-					const prev = dispatchQueues.get(connectionID) ?? Promise.resolve();
-					prev
-						.then(() =>
-							dispatchWebSocketClose(
-								registration,
-								upgrade.client,
-								evt.code,
-								evt.reason,
-								evt.wasClean,
-							),
-						)
-						.catch((err) => {
-							logger.error("WebSocket close dispatch failed: {error}", {
-								error: err,
-							});
-						})
-						.finally(() => {
-							shovelClients?.removeWebSocketClient(connectionID);
-							dispatchQueues.delete(connectionID);
-						});
-				});
-
-				return new Response(null, {
-					status: 101,
-					webSocket: client,
-				} as any);
-			}
-
-			return response!;
-		});
+		return envStorage.run(envRecord, () =>
+			dispatchRequest(registration, event),
+		);
 	};
 }
 

--- a/packages/platform-cloudflare/src/websocket-do.ts
+++ b/packages/platform-cloudflare/src/websocket-do.ts
@@ -15,6 +15,7 @@ import {
 	kGetUpgradeResult,
 	dispatchWebSocketMessage,
 	dispatchWebSocketClose,
+	setBroadcastChannelBackend,
 } from "@b9g/platform/runtime";
 import {CloudflareFetchEvent} from "./runtime.js";
 import {envStorage} from "./variables.js";
@@ -82,6 +83,17 @@ export class ShovelWebSocketDO extends DurableObject {
 		// activated in this isolate.
 		if (!this.#registration.ready) {
 			await runLifecycle(this.#registration, "activate");
+		}
+
+		// Configure BroadcastChannel backend in the DO isolate if available
+		const env = (this.env ?? {}) as Record<string, unknown>;
+		if (env.SHOVEL_PUBSUB) {
+			const {CloudflarePubSubBackend} = await import("./pubsub.js");
+			setBroadcastChannelBackend(
+				new CloudflarePubSubBackend(
+					env.SHOVEL_PUBSUB as DurableObjectNamespace,
+				),
+			);
 		}
 
 		this.#shovelClients =

--- a/packages/platform-cloudflare/src/websocket-do.ts
+++ b/packages/platform-cloudflare/src/websocket-do.ts
@@ -114,11 +114,21 @@ export class ShovelWebSocketDO extends DurableObject {
 		const env = (this.env ?? {}) as Record<string, unknown>;
 
 		return envStorage.run(env, async () => {
+			// Buffer messages sent during the fetch handler (before the real socket exists)
+			const pendingMessages: Array<
+				| {type: "send"; data: string | ArrayBuffer}
+				| {type: "close"; code?: number; reason?: string}
+			> = [];
+
 			const cfEvent = new CloudflareFetchEvent(request, {
 				env,
 				wsRelay: {
-					send() {},
-					close() {},
+					send(_id: string, data: string | ArrayBuffer) {
+						pendingMessages.push({type: "send", data});
+					},
+					close(_id: string, code?: number, reason?: string) {
+						pendingMessages.push({type: "close", code, reason});
+					},
 				},
 			});
 
@@ -137,6 +147,7 @@ export class ShovelWebSocketDO extends DurableObject {
 
 				this.ctx.acceptWebSocket(server);
 
+				// Bind the live relay
 				upgrade.client.setRelay({
 					send(_id: string, data: string | ArrayBuffer) {
 						server.send(data);
@@ -145,6 +156,15 @@ export class ShovelWebSocketDO extends DurableObject {
 						server.close(code ?? 1000, reason ?? "");
 					},
 				});
+
+				// Flush any messages buffered during the fetch handler
+				for (const msg of pendingMessages) {
+					if (msg.type === "send") {
+						server.send(msg.data);
+					} else if (msg.type === "close") {
+						server.close(msg.code ?? 1000, msg.reason ?? "");
+					}
+				}
 
 				this.#shovelClients?.registerWebSocketClient(upgrade.client);
 
@@ -170,6 +190,14 @@ export class ShovelWebSocketDO extends DurableObject {
 		const prev = this.#dispatchQueues.get(connectionID) ?? Promise.resolve();
 		const next = prev
 			.then(() => dispatchWebSocketMessage(registration, client, message))
+			.then(() => {
+				// Persist client.data mutations for hibernation survival
+				(ws as any).serializeAttachment({
+					connectionID: client.id,
+					url: client.url,
+					data: client.data,
+				} satisfies WSAttachment);
+			})
 			.catch((err) => {
 				logger.error("WebSocket message dispatch failed: {error}", {
 					error: err,

--- a/packages/platform-cloudflare/src/websocket-do.ts
+++ b/packages/platform-cloudflare/src/websocket-do.ts
@@ -10,6 +10,7 @@ import {
 	ShovelServiceWorkerRegistration,
 	ShovelWebSocketClient,
 	ShovelClients,
+	runLifecycle,
 	dispatchFetchEvent,
 	kGetUpgradeResult,
 	dispatchWebSocketMessage,
@@ -75,9 +76,13 @@ export class ShovelWebSocketDO extends DurableObject {
 			);
 		}
 
-		// Skip lifecycle — the Worker's createFetchHandler already ran
-		// runLifecycle(registration, "activate") before forwarding to this DO.
-		// Re-running would throw since the registration is already activated.
+		// Run lifecycle if needed. On the initial request, the Worker already
+		// activated before forwarding to this DO. But after hibernation wake-up,
+		// the module is re-evaluated with a fresh registration that hasn't been
+		// activated in this isolate.
+		if (!this.#registration.ready) {
+			await runLifecycle(this.#registration, "activate");
+		}
 
 		this.#shovelClients =
 			typeof self !== "undefined" &&
@@ -179,13 +184,18 @@ export class ShovelWebSocketDO extends DurableObject {
 		message: string | ArrayBuffer,
 	): Promise<void> {
 		const registration = await this.#ensureRuntime();
+		const env = (this.env ?? {}) as Record<string, unknown>;
 		const client = this.#clientFromSocket(ws);
 		this.#shovelClients?.registerWebSocketClient(client);
 
 		const connectionID = client.id;
 		const prev = this.#dispatchQueues.get(connectionID) ?? Promise.resolve();
 		const next = prev
-			.then(() => dispatchWebSocketMessage(registration, client, message))
+			.then(() =>
+				envStorage.run(env, () =>
+					dispatchWebSocketMessage(registration, client, message),
+				),
+			)
 			.then(() => {
 				// Persist client.data mutations for hibernation survival
 				(ws as any).serializeAttachment({
@@ -209,13 +219,16 @@ export class ShovelWebSocketDO extends DurableObject {
 		wasClean: boolean,
 	): Promise<void> {
 		const registration = await this.#ensureRuntime();
+		const env = (this.env ?? {}) as Record<string, unknown>;
 		const client = this.#clientFromSocket(ws);
 
 		const connectionID = client.id;
 		const prev = this.#dispatchQueues.get(connectionID) ?? Promise.resolve();
 		prev
 			.then(() =>
-				dispatchWebSocketClose(registration, client, code, reason, wasClean),
+				envStorage.run(env, () =>
+					dispatchWebSocketClose(registration, client, code, reason, wasClean),
+				),
 			)
 			.catch((err) => {
 				logger.error("WebSocket close dispatch failed: {error}", {

--- a/packages/platform-cloudflare/src/websocket-do.ts
+++ b/packages/platform-cloudflare/src/websocket-do.ts
@@ -10,7 +10,6 @@ import {
 	ShovelServiceWorkerRegistration,
 	ShovelWebSocketClient,
 	ShovelClients,
-	runLifecycle,
 	dispatchFetchEvent,
 	kGetUpgradeResult,
 	dispatchWebSocketMessage,
@@ -77,13 +76,10 @@ export class ShovelWebSocketDO extends DurableObject {
 			);
 		}
 
-		// Run lifecycle if needed. On the initial request, the Worker already
-		// activated before forwarding to this DO. But after hibernation wake-up,
-		// the module is re-evaluated with a fresh registration that hasn't been
-		// activated in this isolate.
-		if (!this.#registration.ready) {
-			await runLifecycle(this.#registration, "activate");
-		}
+		// Skip lifecycle in DO — the worker already ran install/activate
+		// before forwarding. After hibernation wake-up, the module is
+		// re-evaluated (event handlers re-registered) but lifecycle side
+		// effects (migrations, cache warming) don't need to re-run.
 
 		// Configure BroadcastChannel backend in the DO isolate if available
 		const env = (this.env ?? {}) as Record<string, unknown>;

--- a/packages/platform-cloudflare/src/websocket-do.ts
+++ b/packages/platform-cloudflare/src/websocket-do.ts
@@ -90,6 +90,16 @@ export class ShovelWebSocketDO extends DurableObject {
 				? ((self as any).clients as ShovelClients)
 				: null;
 
+		// Rehydrate all existing WebSocket connections from hibernation storage.
+		// After wake-up, ctx.getWebSockets() returns all accepted sockets but
+		// self.clients is empty. Rebuild so matchAll/get see all connections.
+		if (this.#shovelClients) {
+			for (const ws of this.ctx.getWebSockets()) {
+				const client = this.#clientFromSocket(ws);
+				this.#shovelClients.registerWebSocketClient(client);
+			}
+		}
+
 		return this.#registration;
 	}
 
@@ -123,6 +133,8 @@ export class ShovelWebSocketDO extends DurableObject {
 
 			const cfEvent = new CloudflareFetchEvent(request, {
 				env,
+				platformWaitUntil: (promise: Promise<unknown>) =>
+					this.ctx.waitUntil(promise),
 				wsRelay: {
 					send(_id: string, data: string | ArrayBuffer) {
 						pendingMessages.push({type: "send", data});

--- a/packages/platform-cloudflare/src/websocket-do.ts
+++ b/packages/platform-cloudflare/src/websocket-do.ts
@@ -164,11 +164,23 @@ export class ShovelWebSocketDO extends DurableObject {
 				const pair = new WebSocketPair();
 				const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
 
-				(server as any).serializeAttachment({
-					connectionID: upgrade.client.id,
-					url: request.url,
-					data: upgrade.client.data,
-				} satisfies WSAttachment);
+				try {
+					(server as any).serializeAttachment({
+						connectionID: upgrade.client.id,
+						url: request.url,
+						data: upgrade.client.data,
+					} satisfies WSAttachment);
+				} catch {
+					// data is not structured-cloneable — store without it
+					(server as any).serializeAttachment({
+						connectionID: upgrade.client.id,
+						url: request.url,
+						data: null,
+					} satisfies WSAttachment);
+					logger.warn(
+						"client.data is not structured-cloneable and will not survive hibernation",
+					);
+				}
 
 				this.ctx.acceptWebSocket(server);
 
@@ -227,11 +239,15 @@ export class ShovelWebSocketDO extends DurableObject {
 					)
 					.then(() => {
 						// Persist client.data mutations for hibernation survival
-						(ws as any).serializeAttachment({
-							connectionID: client.id,
-							url: client.url,
-							data: client.data,
-						} satisfies WSAttachment);
+						try {
+							(ws as any).serializeAttachment({
+								connectionID: client.id,
+								url: client.url,
+								data: client.data,
+							} satisfies WSAttachment);
+						} catch {
+							// data not structured-cloneable — skip persistence
+						}
 					});
 			})
 			.catch((err) => {

--- a/packages/platform-cloudflare/src/websocket-do.ts
+++ b/packages/platform-cloudflare/src/websocket-do.ts
@@ -10,7 +10,6 @@ import {
 	ShovelServiceWorkerRegistration,
 	ShovelWebSocketClient,
 	ShovelClients,
-	runLifecycle,
 	dispatchFetchEvent,
 	kGetUpgradeResult,
 	dispatchWebSocketMessage,
@@ -77,12 +76,13 @@ export class ShovelWebSocketDO extends DurableObject {
 			);
 		}
 
-		// Run lifecycle if needed. On the initial request, the Worker already
-		// activated before forwarding to this DO. But after hibernation wake-up,
-		// the module is re-evaluated with a fresh registration that hasn't been
-		// activated in this isolate.
+		// Don't re-run lifecycle in the DO — the worker already ran
+		// install/activate before forwarding. With per-connection DOs,
+		// re-running would duplicate migrations/cache warming per connection.
+		// Just mark as activated so event dispatch works.
 		if (!this.#registration.ready) {
-			await runLifecycle(this.#registration, "activate");
+			const {kServiceWorker} = await import("@b9g/platform/runtime");
+			(this.#registration as any)[kServiceWorker]._setState("activated");
 		}
 
 		// Configure BroadcastChannel backend in the DO isolate if available

--- a/packages/platform-cloudflare/src/websocket-do.ts
+++ b/packages/platform-cloudflare/src/websocket-do.ts
@@ -10,6 +10,7 @@ import {
 	ShovelServiceWorkerRegistration,
 	ShovelWebSocketClient,
 	ShovelClients,
+	runLifecycle,
 	dispatchFetchEvent,
 	kGetUpgradeResult,
 	dispatchWebSocketMessage,
@@ -76,10 +77,13 @@ export class ShovelWebSocketDO extends DurableObject {
 			);
 		}
 
-		// Skip lifecycle in DO — the worker already ran install/activate
-		// before forwarding. After hibernation wake-up, the module is
-		// re-evaluated (event handlers re-registered) but lifecycle side
-		// effects (migrations, cache warming) don't need to re-run.
+		// Run lifecycle if needed. On the initial request, the Worker already
+		// activated before forwarding to this DO. But after hibernation wake-up,
+		// the module is re-evaluated with a fresh registration that hasn't been
+		// activated in this isolate.
+		if (!this.#registration.ready) {
+			await runLifecycle(this.#registration, "activate");
+		}
 
 		// Configure BroadcastChannel backend in the DO isolate if available
 		const env = (this.env ?? {}) as Record<string, unknown>;

--- a/packages/platform-cloudflare/src/websocket-do.ts
+++ b/packages/platform-cloudflare/src/websocket-do.ts
@@ -170,7 +170,7 @@ export class ShovelWebSocketDO extends DurableObject {
 						url: request.url,
 						data: upgrade.client.data,
 					} satisfies WSAttachment);
-				} catch {
+				} catch (err) {
 					// data is not structured-cloneable — store without it
 					(server as any).serializeAttachment({
 						connectionID: upgrade.client.id,
@@ -245,8 +245,11 @@ export class ShovelWebSocketDO extends DurableObject {
 								url: client.url,
 								data: client.data,
 							} satisfies WSAttachment);
-						} catch {
-							// data not structured-cloneable — skip persistence
+						} catch (err) {
+							logger.warn(
+								"client.data not structured-cloneable, skipping persistence: {error}",
+								{error: err},
+							);
 						}
 					});
 			})

--- a/packages/platform-cloudflare/src/websocket-do.ts
+++ b/packages/platform-cloudflare/src/websocket-do.ts
@@ -1,0 +1,213 @@
+/**
+ * WebSocket Durable Object with Hibernation API support.
+ *
+ * Separate file because `cloudflare:workers` can only be imported inside workerd.
+ * The generated entry code imports this directly — it's never loaded outside Cloudflare.
+ */
+
+import {DurableObject} from "cloudflare:workers";
+import {
+	ShovelServiceWorkerRegistration,
+	ShovelWebSocketClient,
+	ShovelClients,
+	runLifecycle,
+	dispatchFetchEvent,
+	kGetUpgradeResult,
+	dispatchWebSocketMessage,
+	dispatchWebSocketClose,
+} from "@b9g/platform/runtime";
+import {CloudflareFetchEvent} from "./runtime.js";
+import {envStorage} from "./variables.js";
+import {getLogger} from "@logtape/logtape";
+
+const logger = getLogger(["shovel", "platform"]);
+
+/**
+ * Serialized attachment stored on each accepted WebSocket.
+ * Survives hibernation via ws.serializeAttachment/deserializeAttachment.
+ */
+interface WSAttachment {
+	connectionID: string;
+	url: string;
+	data: unknown;
+}
+
+/**
+ * Durable Object that handles WebSocket connections using the Hibernation API.
+ *
+ * The Worker routes `Upgrade: websocket` requests to this DO. The DO:
+ * 1. Initializes the Shovel runtime + user code (once, or after hibernation wake-up)
+ * 2. Dispatches the fetch event — if upgradeWebSocket() is called, accepts with hibernation
+ * 3. On webSocketMessage/webSocketClose, reconstructs the client and dispatches events
+ *
+ * Because hibernation discards JS state, the runtime and user code are re-initialized
+ * on every wake-up. The ShovelWebSocketClient is reconstructed from the attachment.
+ *
+ * Usage in wrangler.toml:
+ *   [[durable_objects.bindings]]
+ *   name = "SHOVEL_WS"
+ *   class_name = "ShovelWebSocketDO"
+ */
+export class ShovelWebSocketDO extends DurableObject {
+	#registration: ShovelServiceWorkerRegistration | null;
+	#shovelClients: ShovelClients | null;
+	#lifecyclePromise: Promise<void> | null;
+	#dispatchQueues: Map<string, Promise<void>>;
+
+	constructor(ctx: DurableObjectState, env: Record<string, unknown>) {
+		super(ctx, env as any);
+		this.#registration = null;
+		this.#shovelClients = null;
+		this.#lifecyclePromise = null;
+		this.#dispatchQueues = new Map();
+	}
+
+	async #ensureRuntime(): Promise<ShovelServiceWorkerRegistration> {
+		if (this.#registration) return this.#registration;
+
+		// After hibernation, the module is re-evaluated. initializeRuntime()
+		// runs at module level in the generated entry, so _registration exists.
+		// We access it via the global ServiceWorkerRegistration that
+		// ServiceWorkerGlobals installs.
+		const {_getRegistration} = await import("./runtime.js");
+		this.#registration = _getRegistration();
+		if (!this.#registration) {
+			throw new Error(
+				"Shovel runtime not initialized. " +
+					"Ensure initializeRuntime() is called at module level.",
+			);
+		}
+
+		if (!this.#lifecyclePromise) {
+			this.#lifecyclePromise = runLifecycle(this.#registration, "activate");
+		}
+		await this.#lifecyclePromise;
+
+		this.#shovelClients =
+			typeof self !== "undefined" &&
+			(self as any).clients instanceof ShovelClients
+				? ((self as any).clients as ShovelClients)
+				: null;
+
+		return this.#registration;
+	}
+
+	#clientFromSocket(ws: WebSocket): ShovelWebSocketClient {
+		const attachment = (ws as any).deserializeAttachment() as WSAttachment;
+		return new ShovelWebSocketClient({
+			id: attachment.connectionID,
+			url: attachment.url,
+			data: attachment.data,
+			relay: {
+				send(_id: string, data: string | ArrayBuffer) {
+					ws.send(data);
+				},
+				close(_id: string, code?: number, reason?: string) {
+					ws.close(code ?? 1000, reason ?? "");
+				},
+			},
+		});
+	}
+
+	async fetch(request: Request): Promise<Response> {
+		const registration = await this.#ensureRuntime();
+		const env = (this.env ?? {}) as Record<string, unknown>;
+
+		return envStorage.run(env, async () => {
+			const cfEvent = new CloudflareFetchEvent(request, {
+				env,
+				wsRelay: {
+					send() {},
+					close() {},
+				},
+			});
+
+			const {response, event} = await dispatchFetchEvent(registration, cfEvent);
+
+			const upgrade = event[kGetUpgradeResult]?.();
+			if (upgrade) {
+				const pair = new WebSocketPair();
+				const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+
+				(server as any).serializeAttachment({
+					connectionID: upgrade.client.id,
+					url: request.url,
+					data: upgrade.client.data,
+				} satisfies WSAttachment);
+
+				this.ctx.acceptWebSocket(server);
+
+				upgrade.client.setRelay({
+					send(_id: string, data: string | ArrayBuffer) {
+						server.send(data);
+					},
+					close(_id: string, code?: number, reason?: string) {
+						server.close(code ?? 1000, reason ?? "");
+					},
+				});
+
+				this.#shovelClients?.registerWebSocketClient(upgrade.client);
+
+				return new Response(null, {
+					status: 101,
+					webSocket: client,
+				} as any);
+			}
+
+			return response!;
+		});
+	}
+
+	async webSocketMessage(
+		ws: WebSocket,
+		message: string | ArrayBuffer,
+	): Promise<void> {
+		const registration = await this.#ensureRuntime();
+		const client = this.#clientFromSocket(ws);
+		this.#shovelClients?.registerWebSocketClient(client);
+
+		const connectionID = client.id;
+		const prev = this.#dispatchQueues.get(connectionID) ?? Promise.resolve();
+		const next = prev
+			.then(() => dispatchWebSocketMessage(registration, client, message))
+			.catch((err) => {
+				logger.error("WebSocket message dispatch failed: {error}", {
+					error: err,
+				});
+			});
+		this.#dispatchQueues.set(connectionID, next);
+	}
+
+	async webSocketClose(
+		ws: WebSocket,
+		code: number,
+		reason: string,
+		wasClean: boolean,
+	): Promise<void> {
+		const registration = await this.#ensureRuntime();
+		const client = this.#clientFromSocket(ws);
+
+		const connectionID = client.id;
+		const prev = this.#dispatchQueues.get(connectionID) ?? Promise.resolve();
+		prev
+			.then(() =>
+				dispatchWebSocketClose(registration, client, code, reason, wasClean),
+			)
+			.catch((err) => {
+				logger.error("WebSocket close dispatch failed: {error}", {
+					error: err,
+				});
+			})
+			.finally(() => {
+				this.#shovelClients?.removeWebSocketClient(connectionID);
+				this.#dispatchQueues.delete(connectionID);
+			});
+	}
+
+	async webSocketError(ws: WebSocket, error: unknown): Promise<void> {
+		logger.error("WebSocket error: {error}", {error});
+		const client = this.#clientFromSocket(ws);
+		this.#shovelClients?.removeWebSocketClient(client.id);
+		this.#dispatchQueues.delete(client.id);
+	}
+}

--- a/packages/platform-cloudflare/src/websocket-do.ts
+++ b/packages/platform-cloudflare/src/websocket-do.ts
@@ -10,7 +10,6 @@ import {
 	ShovelServiceWorkerRegistration,
 	ShovelWebSocketClient,
 	ShovelClients,
-	runLifecycle,
 	dispatchFetchEvent,
 	kGetUpgradeResult,
 	dispatchWebSocketMessage,
@@ -51,14 +50,12 @@ interface WSAttachment {
 export class ShovelWebSocketDO extends DurableObject {
 	#registration: ShovelServiceWorkerRegistration | null;
 	#shovelClients: ShovelClients | null;
-	#lifecyclePromise: Promise<void> | null;
 	#dispatchQueues: Map<string, Promise<void>>;
 
 	constructor(ctx: DurableObjectState, env: Record<string, unknown>) {
 		super(ctx, env as any);
 		this.#registration = null;
 		this.#shovelClients = null;
-		this.#lifecyclePromise = null;
 		this.#dispatchQueues = new Map();
 	}
 
@@ -78,10 +75,9 @@ export class ShovelWebSocketDO extends DurableObject {
 			);
 		}
 
-		if (!this.#lifecyclePromise) {
-			this.#lifecyclePromise = runLifecycle(this.#registration, "activate");
-		}
-		await this.#lifecyclePromise;
+		// Skip lifecycle — the Worker's createFetchHandler already ran
+		// runLifecycle(registration, "activate") before forwarding to this DO.
+		// Re-running would throw since the registration is already activated.
 
 		this.#shovelClients =
 			typeof self !== "undefined" &&

--- a/packages/platform-cloudflare/src/websocket-do.ts
+++ b/packages/platform-cloudflare/src/websocket-do.ts
@@ -197,24 +197,30 @@ export class ShovelWebSocketDO extends DurableObject {
 	): Promise<void> {
 		const registration = await this.#ensureRuntime();
 		const env = (this.env ?? {}) as Record<string, unknown>;
-		const client = this.#clientFromSocket(ws);
-		this.#shovelClients?.registerWebSocketClient(client);
+		// Read connectionID from attachment for queue key, but defer full
+		// client reconstruction until after previous dispatch completes
+		// so we get the latest client.data after prior mutations.
+		const attachment = (ws as any).deserializeAttachment() as WSAttachment;
+		const connectionID = attachment.connectionID;
 
-		const connectionID = client.id;
 		const prev = this.#dispatchQueues.get(connectionID) ?? Promise.resolve();
 		const next = prev
-			.then(() =>
-				envStorage.run(env, () =>
-					dispatchWebSocketMessage(registration, client, message),
-				),
-			)
 			.then(() => {
-				// Persist client.data mutations for hibernation survival
-				(ws as any).serializeAttachment({
-					connectionID: client.id,
-					url: client.url,
-					data: client.data,
-				} satisfies WSAttachment);
+				// Reconstruct client AFTER previous dispatch to get latest data
+				const client = this.#clientFromSocket(ws);
+				this.#shovelClients?.registerWebSocketClient(client);
+				return envStorage
+					.run(env, () =>
+						dispatchWebSocketMessage(registration, client, message),
+					)
+					.then(() => {
+						// Persist client.data mutations for hibernation survival
+						(ws as any).serializeAttachment({
+							connectionID: client.id,
+							url: client.url,
+							data: client.data,
+						} satisfies WSAttachment);
+					});
 			})
 			.catch((err) => {
 				logger.error("WebSocket message dispatch failed: {error}", {
@@ -222,7 +228,6 @@ export class ShovelWebSocketDO extends DurableObject {
 				});
 			});
 		this.#dispatchQueues.set(connectionID, next);
-		// Return so Cloudflare keeps the handler alive for async work
 		return next;
 	}
 
@@ -234,16 +239,17 @@ export class ShovelWebSocketDO extends DurableObject {
 	): Promise<void> {
 		const registration = await this.#ensureRuntime();
 		const env = (this.env ?? {}) as Record<string, unknown>;
-		const client = this.#clientFromSocket(ws);
+		const attachment = (ws as any).deserializeAttachment() as WSAttachment;
+		const connectionID = attachment.connectionID;
 
-		const connectionID = client.id;
 		const prev = this.#dispatchQueues.get(connectionID) ?? Promise.resolve();
 		const next = prev
-			.then(() =>
-				envStorage.run(env, () =>
+			.then(() => {
+				const client = this.#clientFromSocket(ws);
+				return envStorage.run(env, () =>
 					dispatchWebSocketClose(registration, client, code, reason, wasClean),
-				),
-			)
+				);
+			})
 			.catch((err) => {
 				logger.error("WebSocket close dispatch failed: {error}", {
 					error: err,

--- a/packages/platform-cloudflare/src/websocket-do.ts
+++ b/packages/platform-cloudflare/src/websocket-do.ts
@@ -246,8 +246,15 @@ export class ShovelWebSocketDO extends DurableObject {
 								data: client.data,
 							} satisfies WSAttachment);
 						} catch (err) {
+							// Clear attachment to avoid resurrecting stale data
+							// after hibernation wake-up
+							(ws as any).serializeAttachment({
+								connectionID: client.id,
+								url: client.url,
+								data: null,
+							} satisfies WSAttachment);
 							logger.warn(
-								"client.data not structured-cloneable, skipping persistence: {error}",
+								"client.data not structured-cloneable, cleared for hibernation safety: {error}",
 								{error: err},
 							);
 						}

--- a/packages/platform-cloudflare/src/websocket-do.ts
+++ b/packages/platform-cloudflare/src/websocket-do.ts
@@ -222,6 +222,8 @@ export class ShovelWebSocketDO extends DurableObject {
 				});
 			});
 		this.#dispatchQueues.set(connectionID, next);
+		// Return so Cloudflare keeps the handler alive for async work
+		return next;
 	}
 
 	async webSocketClose(
@@ -236,7 +238,7 @@ export class ShovelWebSocketDO extends DurableObject {
 
 		const connectionID = client.id;
 		const prev = this.#dispatchQueues.get(connectionID) ?? Promise.resolve();
-		prev
+		const next = prev
 			.then(() =>
 				envStorage.run(env, () =>
 					dispatchWebSocketClose(registration, client, code, reason, wasClean),
@@ -251,6 +253,7 @@ export class ShovelWebSocketDO extends DurableObject {
 				this.#shovelClients?.removeWebSocketClient(connectionID);
 				this.#dispatchQueues.delete(connectionID);
 			});
+		return next;
 	}
 
 	async webSocketError(ws: WebSocket, error: unknown): Promise<void> {

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -23,11 +23,13 @@
     "@b9g/http-errors": "workspace:*",
     "@b9g/node-webworker": "workspace:*",
     "@b9g/platform": "workspace:*",
-    "@logtape/logtape": "^2.0.0"
+    "@logtape/logtape": "^2.0.0",
+    "ws": "^8.0.0"
   },
   "devDependencies": {
     "@b9g/libuild": "^0.1.18",
-    "@types/node": "^18.0.0"
+    "@types/node": "^18.0.0",
+    "@types/ws": "^8.0.0"
   },
   "module": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -278,7 +278,15 @@ export class NodePlatform {
 			);
 		}
 
-		this.#server = this.createServer((request) => pool.handleRequest(request));
+		this.#server = this.createServer(
+			async (request) => {
+				const result = await pool.handleRequest(request);
+				// WebSocket upgrades are handled by the httpServer "upgrade" event,
+				// so this handler only sees normal HTTP responses.
+				return result as Response;
+			},
+			{pool},
+		);
 		await this.#server.listen();
 		return this.#server;
 	}
@@ -379,6 +387,90 @@ export class NodePlatform {
 			}
 		});
 
+		// WebSocket upgrade handling (when pool is provided)
+		const pool = options.pool;
+		const wsConnections = new Map<string, any>();
+		if (pool) {
+			let wss: any;
+
+			pool.setWebSocketHandlers({
+				send(connectionID, data) {
+					const ws = wsConnections.get(connectionID);
+					if (ws?.readyState === 1) {
+						ws.send(data);
+					}
+				},
+				close(connectionID, code, reason) {
+					const ws = wsConnections.get(connectionID);
+					if (ws) {
+						ws.close(code ?? 1000, reason ?? "");
+						wsConnections.delete(connectionID);
+					}
+				},
+			});
+
+			httpServer.on("upgrade", async (req, socket, head) => {
+				try {
+					if (!wss) {
+						const ws = await import("ws");
+						wss = new ws.WebSocketServer({noServer: true});
+					}
+
+					const url = `http://${req.headers.host}${req.url}`;
+					const request = new Request(url, {
+						method: req.method,
+						headers: req.headers as HeadersInit,
+					});
+
+					const result = await pool.handleRequest(request);
+
+					if ("upgrade" in result) {
+						wss.handleUpgrade(req, socket, head, (ws: any) => {
+							wsConnections.set(result.connectionID, ws);
+
+							ws.on("message", (data: any, isBinary: boolean) => {
+								if (isBinary) {
+									const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
+									pool.sendWebSocketMessage(
+										result.connectionID,
+										buf.buffer.slice(
+											buf.byteOffset,
+											buf.byteOffset + buf.byteLength,
+										),
+									);
+								} else {
+									pool.sendWebSocketMessage(
+										result.connectionID,
+										data.toString(),
+									);
+								}
+							});
+
+							ws.on("close", (code: number, reason: Buffer) => {
+								pool.sendWebSocketClose(
+									result.connectionID,
+									code,
+									reason.toString(),
+									true,
+								);
+								wsConnections.delete(result.connectionID);
+							});
+
+							ws.on("error", (err: Error) => {
+								logger.error("WebSocket error: {error}", {error: err});
+								wsConnections.delete(result.connectionID);
+							});
+						});
+					} else {
+						socket.destroy();
+					}
+				} catch (error) {
+					logger.error("WebSocket upgrade error: {error}", {error});
+					socket.destroy();
+				}
+			});
+		}
+
 		let isListening = false;
 		let actualPort = port;
 
@@ -406,6 +498,11 @@ export class NodePlatform {
 				});
 			},
 			async close() {
+				// Close all WebSocket connections
+				for (const [id, ws] of wsConnections) {
+					ws.close(1001, "Server shutting down");
+					wsConnections.delete(id);
+				}
 				return new Promise<void>((resolve) => {
 					httpServer.close(() => {
 						isListening = false;
@@ -487,7 +584,7 @@ if (config.lifecycle) {
 		const prodWorkerCode = `// Node.js Production Worker
 import {parentPort} from "node:worker_threads";
 import {getLogger} from "@logtape/logtape";
-import {configureLogging, initWorkerRuntime, runLifecycle, startWorkerMessageLoop, dispatchRequest} from "@b9g/platform/runtime";
+import {configureLogging, initWorkerRuntime, runLifecycle, startWorkerMessageLoop, dispatchRequest, createDirectModePool} from "@b9g/platform/runtime";
 import NodePlatform from "@b9g/platform-node";
 import {config} from "shovel:config";
 
@@ -526,10 +623,17 @@ if (config.lifecycle) {
 	if (databases) await databases.closeAll();
 	process.exit(0);
 } else if (directMode) {
-	// Single worker: create own HTTP server
+	// Single worker: create own HTTP server with WebSocket support
+	const pool = createDirectModePool(registration, result.clients);
 	const platform = new NodePlatform({port: config.port, host: config.host});
 	server = platform.createServer(
-		(request) => dispatchRequest(registration, request),
+		async (request) => {
+			const result = await pool.handleRequest(request);
+			// Non-upgrade requests always return Response
+			// (WebSocket upgrades are handled by the httpServer "upgrade" event)
+			return result;
+		},
+		{pool},
 	);
 	await server.listen();
 	parentPort?.postMessage({type: "ready"});

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -584,7 +584,7 @@ if (config.lifecycle) {
 		const prodWorkerCode = `// Node.js Production Worker
 import {parentPort} from "node:worker_threads";
 import {getLogger} from "@logtape/logtape";
-import {configureLogging, initWorkerRuntime, runLifecycle, startWorkerMessageLoop, dispatchRequest, createDirectModePool} from "@b9g/platform/runtime";
+import {configureLogging, initWorkerRuntime, runLifecycle, startWorkerMessageLoop, createDirectModePool} from "@b9g/platform/runtime";
 import NodePlatform from "@b9g/platform-node";
 import {config} from "shovel:config";
 

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -697,8 +697,7 @@ if (config.lifecycle) {
 	server = platform.createServer(
 		async (request) => {
 			const result = await pool.handleRequest(request);
-			// Non-upgrade requests always return Response
-			// (WebSocket upgrades are handled by the httpServer "upgrade" event)
+			if ("upgrade" in result) return new Response("Upgrade Required", {status: 426});
 			return result;
 		},
 		{pool},

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -390,14 +390,44 @@ export class NodePlatform {
 		// WebSocket upgrade handling (when pool is provided)
 		const pool = options.pool;
 		const wsConnections = new Map<string, any>();
+		// Buffer for messages arriving before the real socket is ready
+		const wsPendingMessages = new Map<
+			string,
+			Array<
+				| {type: "send"; data: string | ArrayBuffer}
+				| {type: "close"; code?: number; reason?: string}
+			>
+		>();
 		if (pool) {
 			let wss: any;
+
+			function flushPending(connectionID: string, ws: any) {
+				const pending = wsPendingMessages.get(connectionID);
+				if (pending) {
+					wsPendingMessages.delete(connectionID);
+					for (const msg of pending) {
+						if (msg.type === "send" && ws.readyState === 1) {
+							ws.send(msg.data);
+						} else if (msg.type === "close") {
+							ws.close(msg.code ?? 1000, msg.reason ?? "");
+						}
+					}
+				}
+			}
 
 			pool.setWebSocketHandlers({
 				send(connectionID, data) {
 					const ws = wsConnections.get(connectionID);
 					if (ws?.readyState === 1) {
 						ws.send(data);
+					} else {
+						// Buffer until handleUpgrade completes
+						let buf = wsPendingMessages.get(connectionID);
+						if (!buf) {
+							buf = [];
+							wsPendingMessages.set(connectionID, buf);
+						}
+						buf.push({type: "send", data});
 					}
 				},
 				close(connectionID, code, reason) {
@@ -405,6 +435,13 @@ export class NodePlatform {
 					if (ws) {
 						ws.close(code ?? 1000, reason ?? "");
 						wsConnections.delete(connectionID);
+					} else {
+						let buf = wsPendingMessages.get(connectionID);
+						if (!buf) {
+							buf = [];
+							wsPendingMessages.set(connectionID, buf);
+						}
+						buf.push({type: "close", code, reason});
 					}
 				},
 			});
@@ -427,6 +464,7 @@ export class NodePlatform {
 					if ("upgrade" in result) {
 						wss.handleUpgrade(req, socket, head, (ws: any) => {
 							wsConnections.set(result.connectionID, ws);
+							flushPending(result.connectionID, ws);
 
 							ws.on("message", (data: any, isBinary: boolean) => {
 								if (isBinary) {
@@ -476,8 +514,23 @@ export class NodePlatform {
 						socket.end();
 					}
 				} catch (error) {
-					logger.error("WebSocket upgrade error: {error}", {error});
-					socket.destroy();
+					const err = error instanceof Error ? error : new Error(String(error));
+					const httpError = isHTTPError(error)
+						? (error as HTTPError)
+						: new InternalServerError(err.message, {cause: err});
+					logger.error("WebSocket upgrade error: {error}", {error: err});
+					const isDev = import.meta.env?.MODE !== "production";
+					const errResp = httpError.toResponse(isDev);
+					const errBody = await errResp.text();
+					socket.write(
+						`HTTP/1.1 ${errResp.status} ${errResp.statusText}\r\n` +
+							[...errResp.headers.entries()]
+								.map(([k, v]) => `${k}: ${v}`)
+								.join("\r\n") +
+							`\r\nContent-Length: ${Buffer.byteLength(errBody)}\r\n\r\n` +
+							errBody,
+					);
+					socket.end();
 				}
 			});
 		}

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -475,7 +475,6 @@ export class NodePlatform {
 						upgradeConnectionID = result.connectionID;
 						wss.handleUpgrade(req, socket, head, (ws: any) => {
 							wsConnections.set(result.connectionID, ws);
-							flushPending(result.connectionID, ws);
 
 							ws.on("message", (data: any, isBinary: boolean) => {
 								if (isBinary) {
@@ -511,6 +510,10 @@ export class NodePlatform {
 								logger.error("WebSocket error: {error}", {error: err});
 								wsConnections.delete(result.connectionID);
 							});
+
+							// Flush after listeners are attached so buffered
+							// close/send ops trigger the handlers above
+							flushPending(result.connectionID, ws);
 						});
 					} else {
 						// Worker rejected the upgrade — write the HTTP response back

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -462,7 +462,18 @@ export class NodePlatform {
 							});
 						});
 					} else {
-						socket.destroy();
+						// Worker rejected the upgrade — write the HTTP response back
+						const resp = result as Response;
+						const body = await resp.text();
+						socket.write(
+							`HTTP/1.1 ${resp.status} ${resp.statusText}\r\n` +
+								[...resp.headers.entries()]
+									.map(([k, v]) => `${k}: ${v}`)
+									.join("\r\n") +
+								`\r\nContent-Length: ${Buffer.byteLength(body)}\r\n\r\n` +
+								body,
+						);
+						socket.end();
 					}
 				} catch (error) {
 					logger.error("WebSocket upgrade error: {error}", {error});

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -282,7 +282,14 @@ export class NodePlatform {
 			async (request) => {
 				const result = await pool.handleRequest(request);
 				if ("upgrade" in result) {
-					// Worker called upgradeWebSocket() but this isn't a WebSocket request
+					// Worker called upgradeWebSocket() but this isn't a WebSocket request —
+					// clean up the connection state the worker already created
+					pool.sendWebSocketClose(
+						result.connectionID,
+						1002,
+						"Not a WebSocket request",
+						false,
+					);
 					return new Response("Upgrade Required", {status: 426});
 				}
 				return result;
@@ -711,7 +718,7 @@ if (config.lifecycle) {
 	server = platform.createServer(
 		async (request) => {
 			const result = await pool.handleRequest(request);
-			if ("upgrade" in result) return new Response("Upgrade Required", {status: 426});
+			if ("upgrade" in result) { pool.sendWebSocketClose(result.connectionID, 1002, "Not a WebSocket request", false); return new Response("Upgrade Required", {status: 426}); }
 			return result;
 		},
 		{pool},

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -449,6 +449,7 @@ export class NodePlatform {
 			});
 
 			httpServer.on("upgrade", async (req, socket, head) => {
+				let upgradeConnectionID: string | undefined;
 				try {
 					if (!wss) {
 						const ws = await import("ws");
@@ -464,6 +465,7 @@ export class NodePlatform {
 					const result = await pool.handleRequest(request);
 
 					if ("upgrade" in result) {
+						upgradeConnectionID = result.connectionID;
 						wss.handleUpgrade(req, socket, head, (ws: any) => {
 							wsConnections.set(result.connectionID, ws);
 							flushPending(result.connectionID, ws);
@@ -523,6 +525,18 @@ export class NodePlatform {
 						? (error as HTTPError)
 						: new InternalServerError(err.message, {cause: err});
 					logger.error("WebSocket upgrade error: {error}", {error: err});
+
+					// Clean up worker-side state if upgrade was already registered
+					if (upgradeConnectionID) {
+						pool.sendWebSocketClose(
+							upgradeConnectionID,
+							1006,
+							"Upgrade failed",
+							false,
+						);
+						wsPendingMessages.delete(upgradeConnectionID);
+					}
+
 					const isDev = import.meta.env?.MODE !== "production";
 					const errResp = httpError.toResponse(isDev);
 					const errBody = await errResp.text();

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -281,9 +281,11 @@ export class NodePlatform {
 		this.#server = this.createServer(
 			async (request) => {
 				const result = await pool.handleRequest(request);
-				// WebSocket upgrades are handled by the httpServer "upgrade" event,
-				// so this handler only sees normal HTTP responses.
-				return result as Response;
+				if ("upgrade" in result) {
+					// Worker called upgradeWebSocket() but this isn't a WebSocket request
+					return new Response("Upgrade Required", {status: 426});
+				}
+				return result;
 			},
 			{pool},
 		);
@@ -485,11 +487,13 @@ export class NodePlatform {
 							});
 
 							ws.on("close", (code: number, reason: Buffer) => {
+								// 1006 = abnormal closure (no close frame received)
+								const wasClean = code !== 1006;
 								pool.sendWebSocketClose(
 									result.connectionID,
 									code,
 									reason.toString(),
-									true,
+									wasClean,
 								);
 								wsConnections.delete(result.connectionID);
 							});

--- a/packages/platform-node/src/platform.ts
+++ b/packages/platform-node/src/platform.ts
@@ -84,7 +84,7 @@ if (config.lifecycle) {
 	const prodWorkerCode = `// Node.js Production Worker
 import {parentPort} from "node:worker_threads";
 import {getLogger} from "@logtape/logtape";
-import {configureLogging, initWorkerRuntime, runLifecycle, startWorkerMessageLoop, dispatchRequest} from "@b9g/platform/runtime";
+import {configureLogging, initWorkerRuntime, runLifecycle, startWorkerMessageLoop, createDirectModePool} from "@b9g/platform/runtime";
 import NodePlatform from "@b9g/platform-node";
 import {config} from "shovel:config";
 
@@ -123,10 +123,15 @@ if (config.lifecycle) {
 	if (databases) await databases.closeAll();
 	process.exit(0);
 } else if (directMode) {
-	// Single worker: create own HTTP server
+	// Single worker: create own HTTP server with WebSocket support
+	const pool = createDirectModePool(registration, result.clients);
 	const platform = new NodePlatform({port: config.port, host: config.host});
 	server = platform.createServer(
-		(request) => dispatchRequest(registration, request),
+		async (request) => {
+			const r = await pool.handleRequest(request);
+			return r;
+		},
+		{pool},
 	);
 	await server.listen();
 	parentPort?.postMessage({type: "ready"});

--- a/packages/platform-node/src/platform.ts
+++ b/packages/platform-node/src/platform.ts
@@ -129,6 +129,7 @@ if (config.lifecycle) {
 	server = platform.createServer(
 		async (request) => {
 			const r = await pool.handleRequest(request);
+			if ("upgrade" in r) return new Response("Upgrade Required", {status: 426});
 			return r;
 		},
 		{pool},

--- a/packages/platform-node/src/platform.ts
+++ b/packages/platform-node/src/platform.ts
@@ -129,7 +129,7 @@ if (config.lifecycle) {
 	server = platform.createServer(
 		async (request) => {
 			const r = await pool.handleRequest(request);
-			if ("upgrade" in r) return new Response("Upgrade Required", {status: 426});
+			if ("upgrade" in r) { pool.sendWebSocketClose(r.connectionID, 1002, "Not a WebSocket request", false); return new Response("Upgrade Required", {status: 426}); }
 			return r;
 		},
 		{pool},

--- a/packages/platform/src/globals.d.ts
+++ b/packages/platform/src/globals.d.ts
@@ -96,6 +96,55 @@ declare global {
 	}
 
 	/**
+	 * WebSocket client accessible from websocketmessage/websocketclose events.
+	 * Created by FetchEvent.upgradeWebSocket().
+	 */
+	interface WebSocketClient extends Client {
+		/** Arbitrary user data attached during upgradeWebSocket() */
+		readonly data: any;
+		/** Send a message to the connected client */
+		send(data: string | ArrayBuffer): void;
+		/** Close the WebSocket connection */
+		close(code?: number, reason?: string): void;
+	}
+
+	/**
+	 * Event dispatched when a WebSocket message is received.
+	 */
+	interface WebSocketMessageEvent extends ExtendableEvent {
+		/** The WebSocket client that sent the message */
+		readonly source: WebSocketClient;
+		/** The message data (string or ArrayBuffer) */
+		readonly data: string | ArrayBuffer;
+	}
+
+	/**
+	 * Event dispatched when a WebSocket connection closes.
+	 */
+	interface WebSocketCloseEvent extends ExtendableEvent {
+		/** The WebSocket client that disconnected */
+		readonly source: WebSocketClient;
+		/** The close code */
+		readonly code: number;
+		/** The close reason */
+		readonly reason: string;
+		/** Whether the close was clean */
+		readonly wasClean: boolean;
+	}
+
+	/**
+	 * Augment FetchEvent with WebSocket upgrade support.
+	 */
+	interface FetchEvent {
+		/**
+		 * Upgrade this request to a WebSocket connection.
+		 * Returns a WebSocketClient for sending messages.
+		 * No respondWith() call is needed — the upgrade replaces the HTTP response.
+		 */
+		upgradeWebSocket(options?: {data?: any}): WebSocketClient;
+	}
+
+	/**
 	 * Augment WorkerGlobalScopeEventMap with ServiceWorker events.
 	 *
 	 * TypeScript's lib.webworker.d.ts declares `self` as `WorkerGlobalScope`, not
@@ -113,6 +162,8 @@ declare global {
 		activate: ExtendableEvent;
 		message: ExtendableMessageEvent;
 		messageerror: MessageEvent;
+		websocketmessage: WebSocketMessageEvent;
+		websocketclose: WebSocketCloseEvent;
 	}
 
 	/**

--- a/packages/platform/src/globals.d.ts
+++ b/packages/platform/src/globals.d.ts
@@ -96,7 +96,7 @@ declare global {
 	}
 
 	/**
-	 * WebSocket client accessible from websocketmessage/websocketclose events.
+	 * WebSocket client accessible from wsmessage/wsclose events.
 	 * Created by FetchEvent.upgradeWebSocket().
 	 */
 	interface WebSocketClient extends Client {
@@ -174,8 +174,8 @@ declare global {
 		activate: ExtendableEvent;
 		message: ExtendableMessageEvent;
 		messageerror: MessageEvent;
-		websocketmessage: WebSocketMessageEvent;
-		websocketclose: WebSocketCloseEvent;
+		wsmessage: WebSocketMessageEvent;
+		wsclose: WebSocketCloseEvent;
 	}
 
 	/**

--- a/packages/platform/src/globals.d.ts
+++ b/packages/platform/src/globals.d.ts
@@ -109,6 +109,18 @@ declare global {
 	}
 
 	/**
+	 * Extend Clients API with WebSocket client lookup.
+	 *
+	 * Usage:
+	 *   const ws = await self.clients.get(connectionID) as WebSocketClient;
+	 *   const all = await self.clients.matchAll({type: "websocket"} as any) as WebSocketClient[];
+	 */
+	interface Clients {
+		/** Get a client by ID — returns WebSocketClient for WebSocket connections */
+		get(id: string): Promise<WebSocketClient | Client | undefined>;
+	}
+
+	/**
 	 * Event dispatched when a WebSocket message is received.
 	 */
 	interface WebSocketMessageEvent extends ExtendableEvent {

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -639,6 +639,15 @@ export class ServiceWorkerPool {
 						connectionID: message.connectionID,
 					});
 					this.#pendingRequests.delete(message.requestID);
+				} else {
+					// Request already timed out — tell the worker to clean up
+					worker.postMessage({
+						type: "ws:close",
+						connectionID: message.connectionID,
+						code: 1001,
+						reason: "Upgrade timed out",
+						wasClean: false,
+					});
 				}
 				break;
 			}

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -1012,19 +1012,11 @@ export class ServiceWorkerPool {
 	#closeWorkerWebSockets(worker: Worker): void {
 		for (const [connectionID, conn] of this.#wsConnections) {
 			if (conn.worker === worker) {
-				// Notify the worker before removing state, so websocketclose handlers run
-				worker.postMessage({
-					type: "ws:close",
-					connectionID,
-					code: 1012,
-					reason: "Service Restart",
-					wasClean: false,
-				});
-				// Close the real socket
+				// Close the real socket first and let the normal adapter close path
+				// deliver websocketclose while ownership is still tracked.
 				if (this.#wsCloseCallback) {
 					this.#wsCloseCallback(connectionID, 1012, "Service Restart");
 				}
-				this.#wsConnections.delete(connectionID);
 			}
 		}
 	}

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -1012,6 +1012,15 @@ export class ServiceWorkerPool {
 	#closeWorkerWebSockets(worker: Worker): void {
 		for (const [connectionID, conn] of this.#wsConnections) {
 			if (conn.worker === worker) {
+				// Notify the worker before removing state, so websocketclose handlers run
+				worker.postMessage({
+					type: "ws:close",
+					connectionID,
+					code: 1012,
+					reason: "Service Restart",
+					wasClean: false,
+				});
+				// Close the real socket
 				if (this.#wsCloseCallback) {
 					this.#wsCloseCallback(connectionID, 1012, "Service Restart");
 				}

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -651,6 +651,9 @@ export class ServiceWorkerPool {
 			}
 
 			case "ws:close": {
+				// Close the real socket — the adapter's close callback will call
+				// sendWebSocketClose() which routes websocketclose back to the worker
+				// and cleans up #wsConnections.
 				if (this.#wsCloseCallback) {
 					this.#wsCloseCallback(
 						message.connectionID,
@@ -658,7 +661,6 @@ export class ServiceWorkerPool {
 						message.reason,
 					);
 				}
-				this.#wsConnections.delete(message.connectionID);
 				break;
 			}
 

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -877,6 +877,8 @@ export class ServiceWorkerPool {
 		for (const worker of this.#workers) {
 			this.#closeWorkerWebSockets(worker);
 		}
+		// Yield to let close callbacks fire and deliver wsclose to workers
+		await new Promise((resolve) => setTimeout(resolve, 0));
 
 		// Gracefully shutdown existing workers - close resources before terminating
 		const shutdownPromises = this.#workers.map((worker) =>
@@ -923,6 +925,8 @@ export class ServiceWorkerPool {
 		for (const worker of this.#workers) {
 			this.#closeWorkerWebSockets(worker);
 		}
+		// Yield to let close callbacks fire and deliver wsclose to workers
+		await new Promise((resolve) => setTimeout(resolve, 0));
 
 		// Gracefully shutdown workers first (close databases, etc.)
 		const shutdownPromises = this.#workers.map((worker) =>

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -661,7 +661,7 @@ export class ServiceWorkerPool {
 
 			case "ws:close": {
 				// Close the real socket — the adapter's close callback will call
-				// sendWebSocketClose() which routes websocketclose back to the worker
+				// sendWebSocketClose() which routes wsclose back to the worker
 				// and cleans up #wsConnections.
 				if (this.#wsCloseCallback) {
 					this.#wsCloseCallback(
@@ -1024,7 +1024,7 @@ export class ServiceWorkerPool {
 		for (const [connectionID, conn] of this.#wsConnections) {
 			if (conn.worker === worker) {
 				// Close the real socket first and let the normal adapter close path
-				// deliver websocketclose while ownership is still tracked.
+				// deliver wsclose while ownership is still tracked.
 				if (this.#wsCloseCallback) {
 					this.#wsCloseCallback(connectionID, 1012, "Service Restart");
 				}

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -37,6 +37,36 @@ export interface ServerOptions {
 	host?: string;
 	/** Enable SO_REUSEPORT for multi-worker deployments (Bun only) */
 	reusePort?: boolean;
+	/** WebSocket-capable dispatcher (ServiceWorkerPool or direct mode adapter) */
+	pool?: WebSocketDispatcher;
+}
+
+/**
+ * Returned by handleRequest() when the worker upgrades to WebSocket.
+ * Platform adapters check for this instead of a Response.
+ */
+export interface WebSocketUpgradeResult {
+	readonly upgrade: true;
+	readonly connectionID: string;
+}
+
+/**
+ * Interface for WebSocket-capable request dispatchers.
+ * Both ServiceWorkerPool and direct mode adapters implement this.
+ */
+export interface WebSocketDispatcher {
+	handleRequest(request: Request): Promise<Response | WebSocketUpgradeResult>;
+	setWebSocketHandlers(handlers: {
+		send: (connectionID: string, data: string | ArrayBuffer) => void;
+		close: (connectionID: string, code?: number, reason?: string) => void;
+	}): void;
+	sendWebSocketMessage(connectionID: string, data: string | ArrayBuffer): void;
+	sendWebSocketClose(
+		connectionID: string,
+		code: number,
+		reason: string,
+		wasClean: boolean,
+	): void;
 }
 
 /**
@@ -422,7 +452,7 @@ export class ServiceWorkerPool {
 	#pendingRequests: Map<
 		number,
 		{
-			resolve: (response: Response) => void;
+			resolve: (response: Response | WebSocketUpgradeResult) => void;
 			reject: (error: Error) => void;
 			timeoutId?: ReturnType<typeof setTimeout>;
 		}
@@ -444,6 +474,15 @@ export class ServiceWorkerPool {
 		resolve: () => void;
 		reject: (error: Error) => void;
 	}>;
+	// WebSocket connection tracking: connectionID -> worker
+	#wsConnections: Map<string, {workerIndex: number; worker: Worker}>;
+	// Platform-provided callbacks for real socket I/O
+	#wsSendCallback:
+		| ((connectionID: string, data: string | ArrayBuffer) => void)
+		| null;
+	#wsCloseCallback:
+		| ((connectionID: string, code?: number, reason?: string) => void)
+		| null;
 
 	constructor(
 		options: WorkerPoolOptions = {},
@@ -456,6 +495,9 @@ export class ServiceWorkerPool {
 		this.#pendingRequests = new Map();
 		this.#pendingWorkerReady = new Map();
 		this.#workerAvailableWaiters = [];
+		this.#wsConnections = new Map();
+		this.#wsSendCallback = null;
+		this.#wsCloseCallback = null;
 		this.#appEntrypoint = appEntrypoint;
 		this.#cacheStorage = cacheStorage;
 		this.#options = {
@@ -581,6 +623,45 @@ export class ServiceWorkerPool {
 				this.#handleError(message as WorkerErrorMessage);
 				break;
 
+			case "ws:upgrade": {
+				const upgradePending = this.#pendingRequests.get(message.requestID);
+				if (upgradePending) {
+					if (upgradePending.timeoutId) {
+						clearTimeout(upgradePending.timeoutId);
+					}
+					const workerIndex = this.#workers.indexOf(worker);
+					this.#wsConnections.set(message.connectionID, {
+						workerIndex,
+						worker,
+					});
+					upgradePending.resolve({
+						upgrade: true as const,
+						connectionID: message.connectionID,
+					});
+					this.#pendingRequests.delete(message.requestID);
+				}
+				break;
+			}
+
+			case "ws:send": {
+				if (this.#wsSendCallback) {
+					this.#wsSendCallback(message.connectionID, message.data);
+				}
+				break;
+			}
+
+			case "ws:close": {
+				if (this.#wsCloseCallback) {
+					this.#wsCloseCallback(
+						message.connectionID,
+						message.code,
+						message.reason,
+					);
+				}
+				this.#wsConnections.delete(message.connectionID);
+				break;
+			}
+
 			default:
 				// Handle cache messages from PostMessageCache
 				if (message.type?.startsWith("cache:")) {
@@ -649,7 +730,9 @@ export class ServiceWorkerPool {
 	/**
 	 * Handle HTTP request using round-robin worker selection
 	 */
-	async handleRequest(request: Request): Promise<Response> {
+	async handleRequest(
+		request: Request,
+	): Promise<Response | WebSocketUpgradeResult> {
 		// Wait for workers to be available (e.g., during reload)
 		if (this.#workers.length === 0) {
 			logger.debug("No workers available, waiting for worker to be ready");
@@ -779,6 +862,11 @@ export class ServiceWorkerPool {
 		// Update stored entrypoint
 		this.#appEntrypoint = entrypoint;
 
+		// Close all WebSocket connections before shutting down workers
+		for (const worker of this.#workers) {
+			this.#closeWorkerWebSockets(worker);
+		}
+
 		// Gracefully shutdown existing workers - close resources before terminating
 		const shutdownPromises = this.#workers.map((worker) =>
 			this.#gracefulShutdown(worker),
@@ -820,6 +908,11 @@ export class ServiceWorkerPool {
 	 * Graceful shutdown of all workers
 	 */
 	async terminate(): Promise<void> {
+		// Close all WebSocket connections before shutting down workers
+		for (const worker of this.#workers) {
+			this.#closeWorkerWebSockets(worker);
+		}
+
 		// Gracefully shutdown workers first (close databases, etc.)
 		const shutdownPromises = this.#workers.map((worker) =>
 			this.#gracefulShutdown(worker),
@@ -855,6 +948,76 @@ export class ServiceWorkerPool {
 	 */
 	get ready(): boolean {
 		return this.#workers.length > 0;
+	}
+
+	// =========================================================================
+	// WebSocket API
+	// =========================================================================
+
+	/**
+	 * Set platform callbacks for WebSocket I/O.
+	 * Called by platform adapters (Node.js, Bun) to wire up real socket operations.
+	 */
+	setWebSocketHandlers(handlers: {
+		send: (connectionID: string, data: string | ArrayBuffer) => void;
+		close: (connectionID: string, code?: number, reason?: string) => void;
+	}): void {
+		this.#wsSendCallback = handlers.send;
+		this.#wsCloseCallback = handlers.close;
+	}
+
+	/**
+	 * Send a WebSocket message to the worker that owns this connection.
+	 */
+	sendWebSocketMessage(connectionID: string, data: string | ArrayBuffer): void {
+		const conn = this.#wsConnections.get(connectionID);
+		if (conn) {
+			if (typeof data === "string") {
+				conn.worker.postMessage({type: "ws:message", connectionID, data});
+			} else {
+				conn.worker.postMessage(
+					{type: "ws:message", connectionID, data},
+					[data], // zero-copy transfer
+				);
+			}
+		}
+	}
+
+	/**
+	 * Send a WebSocket close event to the worker that owns this connection.
+	 */
+	sendWebSocketClose(
+		connectionID: string,
+		code: number,
+		reason: string,
+		wasClean: boolean,
+	): void {
+		const conn = this.#wsConnections.get(connectionID);
+		if (conn) {
+			conn.worker.postMessage({
+				type: "ws:close",
+				connectionID,
+				code,
+				reason,
+				wasClean,
+			});
+		}
+		this.#wsConnections.delete(connectionID);
+	}
+
+	/**
+	 * Close all WebSocket connections for a specific worker.
+	 * Sends 1012 (Service Restart) close code to clients.
+	 */
+	#closeWorkerWebSockets(worker: Worker): void {
+		for (const [connectionID, conn] of this.#wsConnections) {
+			if (conn.worker === worker) {
+				if (this.#wsCloseCallback) {
+					this.#wsCloseCallback(connectionID, 1012, "Service Restart");
+				}
+				this.#wsConnections.delete(connectionID);
+			}
+		}
 	}
 }
 

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -1680,10 +1680,13 @@ export async function dispatchRequest(
  */
 export async function dispatchFetchEvent(
 	registration: ShovelServiceWorkerRegistration,
-	request: Request,
+	requestOrEvent: Request | ShovelFetchEvent,
 	options?: ShovelFetchEventInit,
 ): Promise<DispatchFetchResult> {
-	const event = new ShovelFetchEvent(request, options);
+	const event =
+		requestOrEvent instanceof ShovelFetchEvent
+			? requestOrEvent
+			: new ShovelFetchEvent(requestOrEvent, options);
 	const response = await registration[kHandleRequest](event);
 	return {response, event};
 }

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -926,6 +926,14 @@ export class ShovelFetchEvent
 			);
 		}
 
+		// Must be called synchronously during dispatch, same as respondWith()
+		if (!this[kCanExtend]()) {
+			throw new DOMException(
+				"upgradeWebSocket() must be called synchronously during event dispatch",
+				"InvalidStateError",
+			);
+		}
+
 		const connectionID = crypto.randomUUID();
 		const client = new ShovelWebSocketClient({
 			id: connectionID,

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -827,6 +827,11 @@ export interface ShovelFetchEventInit extends EventInit {
 	 * (e.g., Cloudflare's ctx.waitUntil)
 	 */
 	platformWaitUntil?: (promise: Promise<unknown>) => void;
+	/**
+	 * WebSocket relay to attach to clients created by upgradeWebSocket().
+	 * Used by direct-mode pools so send()/close() work inside the fetch handler.
+	 */
+	wsRelay?: WebSocketRelay | null;
 }
 
 /** @internal Symbol for accessing WebSocket upgrade result from ShovelFetchEvent */
@@ -851,6 +856,7 @@ export class ShovelFetchEvent
 	#responsePromise: Promise<Response> | null;
 	#responded: boolean;
 	#platformWaitUntil?: (promise: Promise<unknown>) => void;
+	#wsRelay: WebSocketRelay | null;
 	#upgradeResult: {
 		client: ShovelWebSocketClient;
 		connectionID: string;
@@ -867,6 +873,7 @@ export class ShovelFetchEvent
 		this.#responsePromise = null;
 		this.#responded = false;
 		this.#platformWaitUntil = options?.platformWaitUntil;
+		this.#wsRelay = options?.wsRelay ?? null;
 		this.#upgradeResult = null;
 	}
 
@@ -924,6 +931,7 @@ export class ShovelFetchEvent
 			id: connectionID,
 			url: this.request.url,
 			data: options?.data,
+			relay: this.#wsRelay,
 		});
 
 		this.#upgradeResult = {client, connectionID};
@@ -1660,8 +1668,9 @@ export async function dispatchRequest(
 export async function dispatchFetchEvent(
 	registration: ShovelServiceWorkerRegistration,
 	request: Request,
+	options?: ShovelFetchEventInit,
 ): Promise<DispatchFetchResult> {
-	const event = new ShovelFetchEvent(request);
+	const event = new ShovelFetchEvent(request, options);
 	const response = await registration[kHandleRequest](event);
 	return {response, event};
 }
@@ -1725,10 +1734,13 @@ export function createDirectModePool(
 		async handleRequest(
 			request: Request,
 		): Promise<Response | {upgrade: true; connectionID: string}> {
-			const {response, event} = await dispatchFetchEvent(registration, request);
+			const {response, event} = await dispatchFetchEvent(
+				registration,
+				request,
+				{wsRelay: relay},
+			);
 			const upgrade = event[kGetUpgradeResult]();
 			if (upgrade) {
-				upgrade.client.setRelay(relay);
 				clients.registerWebSocketClient(upgrade.client);
 				return {upgrade: true, connectionID: upgrade.connectionID};
 			}

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -656,11 +656,17 @@ export function createDatabaseFactory(
 // ServiceWorker Event Constants
 // ============================================================================
 
-/** ServiceWorker-specific event types that go to registration instead of native handler */
+/** Standard ServiceWorker event types (W3C spec) */
 const SERVICE_WORKER_EVENTS = ["fetch", "install", "activate"] as const;
 
-function isServiceWorkerEvent(type: string): boolean {
-	return (SERVICE_WORKER_EVENTS as readonly string[]).includes(type);
+/** Shovel extension event types dispatched on the registration */
+const SHOVEL_EVENTS = ["websocketmessage", "websocketclose"] as const;
+
+function isRegistrationEvent(type: string): boolean {
+	return (
+		(SERVICE_WORKER_EVENTS as readonly string[]).includes(type) ||
+		(SHOVEL_EVENTS as readonly string[]).includes(type)
+	);
 }
 
 // Set MODE from NODE_ENV for Vite compatibility
@@ -823,6 +829,9 @@ export interface ShovelFetchEventInit extends EventInit {
 	platformWaitUntil?: (promise: Promise<unknown>) => void;
 }
 
+/** @internal Symbol for accessing WebSocket upgrade result from ShovelFetchEvent */
+export const kGetUpgradeResult = Symbol("getUpgradeResult");
+
 /**
  * Shovel's FetchEvent implementation.
  *
@@ -842,6 +851,10 @@ export class ShovelFetchEvent
 	#responsePromise: Promise<Response> | null;
 	#responded: boolean;
 	#platformWaitUntil?: (promise: Promise<unknown>) => void;
+	#upgradeResult: {
+		client: ShovelWebSocketClient;
+		connectionID: string;
+	} | null;
 
 	constructor(request: Request, options?: ShovelFetchEventInit) {
 		super("fetch", options);
@@ -854,6 +867,7 @@ export class ShovelFetchEvent
 		this.#responsePromise = null;
 		this.#responded = false;
 		this.#platformWaitUntil = options?.platformWaitUntil;
+		this.#upgradeResult = null;
 	}
 
 	override waitUntil(promise: Promise<any>): void {
@@ -894,6 +908,34 @@ export class ShovelFetchEvent
 		return this.#responded;
 	}
 
+	/**
+	 * Upgrade this request to a WebSocket connection.
+	 * Must be called synchronously during fetch event dispatch.
+	 */
+	upgradeWebSocket(options?: {data?: any}): ShovelWebSocketClient {
+		const connectionID = crypto.randomUUID();
+		const client = new ShovelWebSocketClient({
+			id: connectionID,
+			url: this.request.url,
+			data: options?.data,
+		});
+
+		this.#upgradeResult = {client, connectionID};
+
+		// Mark as handled — there is no HTTP response for an upgrade
+		this.#responded = true;
+
+		return client;
+	}
+
+	/** @internal Get upgrade result if upgradeWebSocket() was called */
+	[kGetUpgradeResult](): {
+		client: ShovelWebSocketClient;
+		connectionID: string;
+	} | null {
+		return this.#upgradeResult;
+	}
+
 	/** The URL of the request (convenience property) */
 	get url(): string {
 		return this.request.url;
@@ -917,6 +959,7 @@ export class ShovelActivateEvent extends ShovelExtendableEvent {
 		super("activate", eventInitDict);
 	}
 }
+
 // ============================================================================
 // ServiceWorker API Implementation
 // ============================================================================
@@ -991,22 +1034,125 @@ export class ShovelWindowClient extends ShovelClient implements WindowClient {
 	}
 }
 
+// ============================================================================
+// WebSocket Events (Shovel extensions)
+// ============================================================================
+
+/** Module-level relay for WebSocket send/close (set by startWorkerMessageLoop or platform code) */
+let wsRelay: {
+	send: (connectionID: string, data: string | ArrayBuffer) => void;
+	close: (connectionID: string, code?: number, reason?: string) => void;
+} | null = null;
+
+/**
+ * Set the relay functions for WebSocket message forwarding.
+ * Called by startWorkerMessageLoop (multi-worker) or platform-specific direct mode code.
+ */
+export function setWebSocketRelay(relay: {
+	send: (connectionID: string, data: string | ArrayBuffer) => void;
+	close: (connectionID: string, code?: number, reason?: string) => void;
+}): void {
+	wsRelay = relay;
+}
+
+/**
+ * ShovelWebSocketClient - Represents a WebSocket connection in the worker.
+ *
+ * Created by FetchEvent.upgradeWebSocket(). Provides send/close methods
+ * that relay to the real socket via postMessage or direct dispatch.
+ */
+export class ShovelWebSocketClient extends ShovelClient {
+	/** Arbitrary user data attached during upgradeWebSocket(), persists across events */
+	data: any;
+
+	constructor(options: {id: string; url: string; data?: any}) {
+		super({...options, type: "worker"});
+		this.data = options.data;
+	}
+
+	/** Send a message to the connected WebSocket client */
+	send(data: string | ArrayBuffer): void {
+		if (!wsRelay) {
+			throw new Error(
+				"WebSocket relay not initialized. send() can only be called inside a worker.",
+			);
+		}
+		wsRelay.send(this.id, data);
+	}
+
+	/** Close the WebSocket connection */
+	close(code?: number, reason?: string): void {
+		if (!wsRelay) {
+			throw new Error(
+				"WebSocket relay not initialized. close() can only be called inside a worker.",
+			);
+		}
+		wsRelay.close(this.id, code, reason);
+	}
+}
+
+/**
+ * WebSocketMessageEvent - Dispatched when a WebSocket message is received.
+ */
+export class WebSocketMessageEvent extends ShovelExtendableEvent {
+	readonly source: ShovelWebSocketClient;
+	readonly data: string | ArrayBuffer;
+
+	constructor(source: ShovelWebSocketClient, data: string | ArrayBuffer) {
+		super("websocketmessage");
+		this.source = source;
+		this.data = data;
+	}
+}
+
+/**
+ * WebSocketCloseEvent - Dispatched when a WebSocket connection closes.
+ */
+export class WebSocketCloseEvent extends ShovelExtendableEvent {
+	readonly source: ShovelWebSocketClient;
+	readonly code: number;
+	readonly reason: string;
+	readonly wasClean: boolean;
+
+	constructor(
+		source: ShovelWebSocketClient,
+		code: number,
+		reason: string,
+		wasClean: boolean,
+	) {
+		super("websocketclose");
+		this.source = source;
+		this.code = code;
+		this.reason = reason;
+		this.wasClean = wasClean;
+	}
+}
+
 /**
  * ShovelClients - Internal implementation of Clients for Shovel runtime
  * Note: Standard Clients has no constructor - instances are created internally
  */
 export class ShovelClients implements Clients {
+	#websocketClients: Map<string, ShovelWebSocketClient>;
+
+	constructor() {
+		this.#websocketClients = new Map();
+	}
+
 	async claim(): Promise<void> {
 		// No-op: HTTP servers don't have persistent clients to claim
 	}
 
-	async get(_id: string): Promise<Client | undefined> {
-		return undefined;
+	async get(id: string): Promise<Client | undefined> {
+		return this.#websocketClients.get(id);
 	}
 
 	async matchAll<T extends ClientQueryOptions>(
-		_options?: T,
+		options?: T,
 	): Promise<readonly (T["type"] extends "window" ? WindowClient : Client)[]> {
+		if ((options as any)?.type === "websocket") {
+			return [...this.#websocketClients.values()] as any;
+		}
 		return [] as readonly (T["type"] extends "window"
 			? WindowClient
 			: Client)[];
@@ -1017,6 +1163,21 @@ export class ShovelClients implements Clients {
 			.open("platform")
 			.warn("Clients.openWindow() not supported in server context");
 		return null;
+	}
+
+	/** @internal Get a WebSocket client by ID (synchronous) */
+	getWebSocketClient(id: string): ShovelWebSocketClient | undefined {
+		return this.#websocketClients.get(id);
+	}
+
+	/** @internal Register a WebSocket client connection */
+	registerWebSocketClient(client: ShovelWebSocketClient): void {
+		this.#websocketClients.set(client.id, client);
+	}
+
+	/** @internal Remove a WebSocket client connection */
+	removeWebSocketClient(id: string): void {
+		this.#websocketClients.delete(id);
 	}
 }
 
@@ -1331,7 +1492,7 @@ export class ShovelServiceWorkerRegistration
 	 *
 	 * @param event - The fetch event to handle (created by platform adapter)
 	 */
-	async [kHandleRequest](event: ShovelFetchEvent): Promise<Response> {
+	async [kHandleRequest](event: ShovelFetchEvent): Promise<Response | null> {
 		// Allow fetch during any lifecycle state after parsing (installing, installed,
 		// activating, activated). This enables fetch() during install/activate handlers
 		// for use cases like SSG cache warming. Fetch handlers are registered during
@@ -1356,6 +1517,11 @@ export class ShovelServiceWorkerRegistration
 					"No response provided for fetch event. " +
 						"respondWith() must be called synchronously during event dispatch.",
 				);
+			}
+
+			// WebSocket upgrades have no HTTP response
+			if (event[kGetUpgradeResult]?.()) {
+				return null;
 			}
 
 			// Get the response (may be a Promise)
@@ -1445,6 +1611,16 @@ export async function runLifecycle(
  * const response = await dispatchRequest(registration, event);
  * ```
  */
+/**
+ * Result of dispatchFetchEvent() — either a Response or a WebSocket upgrade.
+ */
+export interface DispatchFetchResult {
+	/** The HTTP response, or null if the request was upgraded to WebSocket */
+	response: Response | null;
+	/** The fetch event (use kGetUpgradeResult to check for WebSocket upgrade) */
+	event: ShovelFetchEvent;
+}
+
 export async function dispatchRequest(
 	registration: ShovelServiceWorkerRegistration,
 	requestOrEvent: Request | ShovelFetchEvent,
@@ -1453,7 +1629,118 @@ export async function dispatchRequest(
 		requestOrEvent instanceof ShovelFetchEvent
 			? requestOrEvent
 			: new ShovelFetchEvent(requestOrEvent);
-	return registration[kHandleRequest](event);
+	const response = await registration[kHandleRequest](event);
+	// For backward compat: non-upgrade requests always return Response
+	return response!;
+}
+
+/**
+ * Dispatch a fetch event and return both the response and event.
+ * Use this instead of dispatchRequest() when you need to detect WebSocket upgrades.
+ */
+export async function dispatchFetchEvent(
+	registration: ShovelServiceWorkerRegistration,
+	request: Request,
+): Promise<DispatchFetchResult> {
+	const event = new ShovelFetchEvent(request);
+	const response = await registration[kHandleRequest](event);
+	return {response, event};
+}
+
+/**
+ * Dispatch a WebSocket message event to a ServiceWorker registration.
+ */
+export async function dispatchWebSocketMessage(
+	registration: ShovelServiceWorkerRegistration,
+	client: ShovelWebSocketClient,
+	data: string | ArrayBuffer,
+): Promise<void> {
+	const event = new WebSocketMessageEvent(client, data);
+	registration.dispatchEvent(event);
+	event[kEndDispatchPhase]();
+	await Promise.all(event.getPromises());
+}
+
+/**
+ * Dispatch a WebSocket close event to a ServiceWorker registration.
+ */
+export async function dispatchWebSocketClose(
+	registration: ShovelServiceWorkerRegistration,
+	client: ShovelWebSocketClient,
+	code: number,
+	reason: string,
+	wasClean: boolean,
+): Promise<void> {
+	const event = new WebSocketCloseEvent(client, code, reason, wasClean);
+	registration.dispatchEvent(event);
+	event[kEndDispatchPhase]();
+	await Promise.all(event.getPromises());
+}
+
+/**
+ * Create a pool-compatible adapter for direct mode (single worker, no message passing).
+ * Returns an object with the same WebSocket interface as ServiceWorkerPool,
+ * so platform createServer() can handle upgrades without knowing the mode.
+ */
+export function createDirectModePool(
+	registration: ShovelServiceWorkerRegistration,
+	clients: ShovelClients,
+) {
+	let sendCallback:
+		| ((connectionID: string, data: string | ArrayBuffer) => void)
+		| null = null;
+	let closeCallback:
+		| ((connectionID: string, code?: number, reason?: string) => void)
+		| null = null;
+
+	// Set up relay so ShovelWebSocketClient.send/close go to the real socket
+	setWebSocketRelay({
+		send(connectionID: string, data: string | ArrayBuffer) {
+			sendCallback?.(connectionID, data);
+		},
+		close(connectionID: string, code?: number, reason?: string) {
+			closeCallback?.(connectionID, code, reason);
+		},
+	});
+
+	return {
+		async handleRequest(
+			request: Request,
+		): Promise<Response | {upgrade: true; connectionID: string}> {
+			const {response, event} = await dispatchFetchEvent(registration, request);
+			const upgrade = event[kGetUpgradeResult]();
+			if (upgrade) {
+				clients.registerWebSocketClient(upgrade.client);
+				return {upgrade: true, connectionID: upgrade.connectionID};
+			}
+			return response!;
+		},
+		setWebSocketHandlers(handlers: {
+			send: (connectionID: string, data: string | ArrayBuffer) => void;
+			close: (connectionID: string, code?: number, reason?: string) => void;
+		}) {
+			sendCallback = handlers.send;
+			closeCallback = handlers.close;
+		},
+		sendWebSocketMessage(connectionID: string, data: string | ArrayBuffer) {
+			const client = clients.getWebSocketClient(connectionID);
+			if (client) {
+				dispatchWebSocketMessage(registration, client, data);
+			}
+		},
+		sendWebSocketClose(
+			connectionID: string,
+			code: number,
+			reason: string,
+			wasClean: boolean,
+		) {
+			const client = clients.getWebSocketClient(connectionID);
+			if (client) {
+				clients.removeWebSocketClient(connectionID);
+				dispatchWebSocketClose(registration, client, code, reason, wasClean);
+			}
+		},
+	};
 }
 
 /**
@@ -2080,7 +2367,7 @@ export class ServiceWorkerGlobals {
 	): void {
 		if (!listener) return;
 
-		if (isServiceWorkerEvent(type)) {
+		if (isRegistrationEvent(type)) {
 			this.registration.addEventListener(type, listener, options);
 		} else {
 			// Other events (e.g., "message" for worker threads) go to native
@@ -2099,7 +2386,7 @@ export class ServiceWorkerGlobals {
 	): void {
 		if (!listener) return;
 
-		if (isServiceWorkerEvent(type)) {
+		if (isRegistrationEvent(type)) {
 			this.registration.removeEventListener(type, listener, options);
 		} else {
 			const original = this.#originals
@@ -2111,7 +2398,7 @@ export class ServiceWorkerGlobals {
 	}
 
 	dispatchEvent(event: Event): boolean {
-		if (isServiceWorkerEvent(event.type)) {
+		if (isRegistrationEvent(event.type)) {
 			return this.registration.dispatchEvent(event);
 		}
 		// Other events go to native
@@ -2419,6 +2706,8 @@ export interface InitWorkerRuntimeResult {
 	databases?: CustomDatabaseStorage;
 	/** Logger storage instance */
 	loggers: CustomLoggerStorage;
+	/** Clients API instance (for WebSocket client tracking) */
+	clients: ShovelClients;
 }
 
 /**
@@ -2507,7 +2796,15 @@ export async function initWorkerRuntime(
 
 	runtimeLogger.debug("Worker runtime initialized");
 
-	return {registration, scope, caches, directories, databases, loggers};
+	return {
+		registration,
+		scope,
+		caches,
+		directories,
+		databases,
+		loggers,
+		clients: scope.clients as unknown as ShovelClients,
+	};
 }
 
 /**
@@ -2542,6 +2839,16 @@ export function startWorkerMessageLoop(
 	const messageLogger = getLogger(["shovel", "platform"]);
 	const workerId = Math.random().toString(36).substring(2, 8);
 
+	// Track WebSocket connections in this worker
+	const wsClients = new Map<string, ShovelWebSocketClient>();
+
+	// Get the ShovelClients instance from self.clients (installed by ServiceWorkerGlobals)
+	const shovelClients =
+		typeof self !== "undefined" &&
+		(self as any).clients instanceof ShovelClients
+			? ((self as any).clients as ShovelClients)
+			: null;
+
 	/**
 	 * Send a message to the main thread
 	 */
@@ -2552,6 +2859,23 @@ export function startWorkerMessageLoop(
 			postMessage(message);
 		}
 	}
+
+	// Set up WebSocket relay so client.send/close relay via postMessage
+	setWebSocketRelay({
+		send(connectionID: string, data: string | ArrayBuffer) {
+			if (typeof data === "string") {
+				sendMessage({type: "ws:send", connectionID, data});
+			} else {
+				sendMessage(
+					{type: "ws:send", connectionID, data},
+					[data], // zero-copy transfer
+				);
+			}
+		},
+		close(connectionID: string, code?: number, reason?: string) {
+			sendMessage({type: "ws:close", connectionID, code, reason});
+		},
+	});
 
 	/**
 	 * Handle a fetch request
@@ -2566,7 +2890,23 @@ export function startWorkerMessageLoop(
 				body: message.request.body,
 			});
 
-			const response = await dispatchRequest(registration, request);
+			const event = new ShovelFetchEvent(request);
+			const response = await dispatchRequest(registration, event);
+
+			// Check if this was a WebSocket upgrade
+			const upgradeResult = event[kGetUpgradeResult]();
+			if (upgradeResult) {
+				const {client, connectionID} = upgradeResult;
+				wsClients.set(connectionID, client);
+				shovelClients?.registerWebSocketClient(client);
+				sendMessage({
+					type: "ws:upgrade",
+					connectionID,
+					data: client.data,
+					requestID: message.requestID,
+				});
+				return;
+			}
 
 			// Use arrayBuffer for zero-copy transfer
 			const body = await response.arrayBuffer();
@@ -2627,6 +2967,44 @@ export function startWorkerMessageLoop(
 					error,
 				});
 			});
+			return;
+		}
+
+		// Handle WebSocket message from main thread
+		if (message?.type === "ws:message") {
+			const client = wsClients.get(message.connectionID);
+			if (client) {
+				dispatchWebSocketMessage(registration, client, message.data).catch(
+					(error) => {
+						messageLogger.error(
+							`[Worker-${workerId}] WebSocket message dispatch failed: {error}`,
+							{error},
+						);
+					},
+				);
+			}
+			return;
+		}
+
+		// Handle WebSocket close from main thread
+		if (message?.type === "ws:close") {
+			const client = wsClients.get(message.connectionID);
+			if (client) {
+				wsClients.delete(message.connectionID);
+				shovelClients?.removeWebSocketClient(message.connectionID);
+				dispatchWebSocketClose(
+					registration,
+					client,
+					message.code ?? 1005,
+					message.reason ?? "",
+					message.wasClean ?? false,
+				).catch((error) => {
+					messageLogger.error(
+						`[Worker-${workerId}] WebSocket close dispatch failed: {error}`,
+						{error},
+					);
+				});
+			}
 			return;
 		}
 

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -1665,8 +1665,13 @@ export async function dispatchRequest(
 			? requestOrEvent
 			: new ShovelFetchEvent(requestOrEvent);
 	const response = await registration[kHandleRequest](event);
-	// For backward compat: non-upgrade requests always return Response
-	return response!;
+	if (response === null) {
+		throw new Error(
+			"Cannot use dispatchRequest() with WebSocket upgrades. " +
+				"Use dispatchFetchEvent() instead to handle upgrade results.",
+		);
+	}
+	return response;
 }
 
 /**
@@ -1723,6 +1728,8 @@ export function createDirectModePool(
 	clients: ShovelClients,
 ) {
 	const logger = getLogger(["shovel", "platform"]);
+	// Per-connection dispatch queue to preserve message ordering
+	const dispatchQueues = new Map<string, Promise<void>>();
 	let sendCallback:
 		| ((connectionID: string, data: string | ArrayBuffer) => void)
 		| null = null;
@@ -1764,11 +1771,15 @@ export function createDirectModePool(
 		sendWebSocketMessage(connectionID: string, data: string | ArrayBuffer) {
 			const client = clients.getWebSocketClient(connectionID);
 			if (client) {
-				dispatchWebSocketMessage(registration, client, data).catch((err) => {
-					logger.error("WebSocket message dispatch failed: {error}", {
-						error: err,
+				const prev = dispatchQueues.get(connectionID) ?? Promise.resolve();
+				const next = prev
+					.then(() => dispatchWebSocketMessage(registration, client, data))
+					.catch((err) => {
+						logger.error("WebSocket message dispatch failed: {error}", {
+							error: err,
+						});
 					});
-				});
+				dispatchQueues.set(connectionID, next);
 			}
 		},
 		sendWebSocketClose(
@@ -1780,17 +1791,25 @@ export function createDirectModePool(
 			const client = clients.getWebSocketClient(connectionID);
 			if (client) {
 				clients.removeWebSocketClient(connectionID);
-				dispatchWebSocketClose(
-					registration,
-					client,
-					code,
-					reason,
-					wasClean,
-				).catch((err) => {
-					logger.error("WebSocket close dispatch failed: {error}", {
-						error: err,
+				const prev = dispatchQueues.get(connectionID) ?? Promise.resolve();
+				prev
+					.then(() =>
+						dispatchWebSocketClose(
+							registration,
+							client,
+							code,
+							reason,
+							wasClean,
+						),
+					)
+					.catch((err) => {
+						logger.error("WebSocket close dispatch failed: {error}", {
+							error: err,
+						});
+					})
+					.finally(() => {
+						dispatchQueues.delete(connectionID);
 					});
-				});
 			}
 		},
 	};
@@ -2894,6 +2913,8 @@ export function startWorkerMessageLoop(
 
 	// Track WebSocket connections in this worker
 	const wsClients = new Map<string, ShovelWebSocketClient>();
+	// Per-connection dispatch queue to preserve message ordering
+	const wsDispatchQueues = new Map<string, Promise<void>>();
 
 	// Get the ShovelClients instance from self.clients (installed by ServiceWorkerGlobals)
 	const shovelClients =
@@ -3027,14 +3048,19 @@ export function startWorkerMessageLoop(
 		if (message?.type === "ws:message") {
 			const client = wsClients.get(message.connectionID);
 			if (client) {
-				dispatchWebSocketMessage(registration, client, message.data).catch(
-					(error) => {
+				const connID = message.connectionID as string;
+				const prev = wsDispatchQueues.get(connID) ?? Promise.resolve();
+				const next = prev
+					.then(() =>
+						dispatchWebSocketMessage(registration, client, message.data),
+					)
+					.catch((error) => {
 						messageLogger.error(
 							`[Worker-${workerId}] WebSocket message dispatch failed: {error}`,
 							{error},
 						);
-					},
-				);
+					});
+				wsDispatchQueues.set(connID, next);
 			}
 			return;
 		}
@@ -3043,20 +3069,29 @@ export function startWorkerMessageLoop(
 		if (message?.type === "ws:close") {
 			const client = wsClients.get(message.connectionID);
 			if (client) {
-				wsClients.delete(message.connectionID);
-				shovelClients?.removeWebSocketClient(message.connectionID);
-				dispatchWebSocketClose(
-					registration,
-					client,
-					message.code ?? 1005,
-					message.reason ?? "",
-					message.wasClean ?? false,
-				).catch((error) => {
-					messageLogger.error(
-						`[Worker-${workerId}] WebSocket close dispatch failed: {error}`,
-						{error},
-					);
-				});
+				const connID = message.connectionID as string;
+				wsClients.delete(connID);
+				shovelClients?.removeWebSocketClient(connID);
+				const prev = wsDispatchQueues.get(connID) ?? Promise.resolve();
+				prev
+					.then(() =>
+						dispatchWebSocketClose(
+							registration,
+							client,
+							message.code ?? 1005,
+							message.reason ?? "",
+							message.wasClean ?? false,
+						),
+					)
+					.catch((error) => {
+						messageLogger.error(
+							`[Worker-${workerId}] WebSocket close dispatch failed: {error}`,
+							{error},
+						);
+					})
+					.finally(() => {
+						wsDispatchQueues.delete(connID);
+					});
 			}
 			return;
 		}

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -926,6 +926,12 @@ export class ShovelFetchEvent
 			);
 		}
 
+		if (this.request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+			throw new Error(
+				"Cannot upgradeWebSocket() on a request without Upgrade: websocket header",
+			);
+		}
+
 		// Must be called synchronously during dispatch, same as respondWith()
 		if (!this[kCanExtend]()) {
 			throw new DOMException(
@@ -1797,7 +1803,6 @@ export function createDirectModePool(
 		) {
 			const client = clients.getWebSocketClient(connectionID);
 			if (client) {
-				clients.removeWebSocketClient(connectionID);
 				const prev = dispatchQueues.get(connectionID) ?? Promise.resolve();
 				prev
 					.then(() =>
@@ -1815,6 +1820,7 @@ export function createDirectModePool(
 						});
 					})
 					.finally(() => {
+						clients.removeWebSocketClient(connectionID);
 						dispatchQueues.delete(connectionID);
 					});
 			}

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -832,6 +832,12 @@ export interface ShovelFetchEventInit extends EventInit {
 	 * Used by direct-mode pools so send()/close() work inside the fetch handler.
 	 */
 	wsRelay?: WebSocketRelay | null;
+	/**
+	 * Callback invoked immediately when upgradeWebSocket() creates a client.
+	 * Allows registering the client before the fetch handler returns,
+	 * so close/send during the handler can find the client.
+	 */
+	onUpgrade?: (client: ShovelWebSocketClient) => void;
 }
 
 /** @internal Symbol for accessing WebSocket upgrade result from ShovelFetchEvent */
@@ -857,6 +863,7 @@ export class ShovelFetchEvent
 	#responded: boolean;
 	#platformWaitUntil?: (promise: Promise<unknown>) => void;
 	#wsRelay: WebSocketRelay | null;
+	#onUpgrade?: (client: ShovelWebSocketClient) => void;
 	#upgradeResult: {
 		client: ShovelWebSocketClient;
 		connectionID: string;
@@ -874,6 +881,7 @@ export class ShovelFetchEvent
 		this.#responded = false;
 		this.#platformWaitUntil = options?.platformWaitUntil;
 		this.#wsRelay = options?.wsRelay ?? null;
+		this.#onUpgrade = options?.onUpgrade;
 		this.#upgradeResult = null;
 	}
 
@@ -952,6 +960,10 @@ export class ShovelFetchEvent
 
 		// Mark as handled — there is no HTTP response for an upgrade
 		this.#responded = true;
+
+		// Notify platform so client is registered before the handler continues
+		// (enables close/send during the fetch handler to find the client)
+		this.#onUpgrade?.(client);
 
 		return client;
 	}
@@ -1765,11 +1777,17 @@ export function createDirectModePool(
 			const {response, event} = await dispatchFetchEvent(
 				registration,
 				request,
-				{wsRelay: relay},
+				{
+					wsRelay: relay,
+					// Register client immediately on upgrade so close/send during
+					// the fetch handler can find it via clients.getWebSocketClient()
+					onUpgrade(client: ShovelWebSocketClient) {
+						clients.registerWebSocketClient(client);
+					},
+				},
 			);
 			const upgrade = event[kGetUpgradeResult]();
 			if (upgrade) {
-				clients.registerWebSocketClient(upgrade.client);
 				return {upgrade: true, connectionID: upgrade.connectionID};
 			}
 			return response!;
@@ -2988,7 +3006,6 @@ export function startWorkerMessageLoop(
 				sendMessage({
 					type: "ws:upgrade",
 					connectionID,
-					data: client.data,
 					requestID: message.requestID,
 				});
 				return;

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -2964,8 +2964,7 @@ export function startWorkerMessageLoop(
 				body: message.request.body,
 			});
 
-			const event = new ShovelFetchEvent(request);
-			const response = await dispatchRequest(registration, event);
+			const {response, event} = await dispatchFetchEvent(registration, request);
 
 			// Check if this was a WebSocket upgrade
 			const upgradeResult = event[kGetUpgradeResult]();
@@ -2982,11 +2981,15 @@ export function startWorkerMessageLoop(
 				return;
 			}
 
+			// Non-upgrade path: response is always non-null here
+			// (upgrade case returns early above)
+			const httpResponse = response!;
+
 			// Use arrayBuffer for zero-copy transfer
-			const body = await response.arrayBuffer();
+			const body = await httpResponse.arrayBuffer();
 
 			// Ensure Content-Type is preserved
-			const headers = Object.fromEntries(response.headers.entries());
+			const headers = Object.fromEntries(httpResponse.headers.entries());
 			if (!headers["Content-Type"] && !headers["content-type"]) {
 				headers["Content-Type"] = "text/plain; charset=utf-8";
 			}
@@ -2994,8 +2997,8 @@ export function startWorkerMessageLoop(
 			const responseMsg: WorkerResponseMessage = {
 				type: "response",
 				response: {
-					status: response.status,
-					statusText: response.statusText,
+					status: httpResponse.status,
+					statusText: httpResponse.statusText,
 					headers,
 					body,
 				},

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -3103,8 +3103,6 @@ export function startWorkerMessageLoop(
 			const client = wsClients.get(message.connectionID);
 			if (client) {
 				const connID = message.connectionID as string;
-				wsClients.delete(connID);
-				shovelClients?.removeWebSocketClient(connID);
 				const prev = wsDispatchQueues.get(connID) ?? Promise.resolve();
 				prev
 					.then(() =>
@@ -3123,6 +3121,10 @@ export function startWorkerMessageLoop(
 						);
 					})
 					.finally(() => {
+						// Remove after dispatch so wsclose handlers can still
+						// see the client via self.clients.get/matchAll
+						wsClients.delete(connID);
+						shovelClients?.removeWebSocketClient(connID);
 						wsDispatchQueues.delete(connID);
 					});
 			}

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -1774,23 +1774,35 @@ export function createDirectModePool(
 		async handleRequest(
 			request: Request,
 		): Promise<Response | {upgrade: true; connectionID: string}> {
-			const {response, event} = await dispatchFetchEvent(
-				registration,
-				request,
-				{
-					wsRelay: relay,
-					// Register client immediately on upgrade so close/send during
-					// the fetch handler can find it via clients.getWebSocketClient()
-					onUpgrade(client: ShovelWebSocketClient) {
-						clients.registerWebSocketClient(client);
+			// Track client ID registered during upgrade for cleanup on failure
+			const upgradedClientId: string[] = [];
+			try {
+				const {response, event} = await dispatchFetchEvent(
+					registration,
+					request,
+					{
+						wsRelay: relay,
+						// Register client immediately on upgrade so close/send during
+						// the fetch handler can find it via clients.getWebSocketClient()
+						onUpgrade(client: ShovelWebSocketClient) {
+							clients.registerWebSocketClient(client);
+							upgradedClientId.push(client.id);
+						},
 					},
-				},
-			);
-			const upgrade = event[kGetUpgradeResult]();
-			if (upgrade) {
-				return {upgrade: true, connectionID: upgrade.connectionID};
+				);
+				const upgrade = event[kGetUpgradeResult]();
+				if (upgrade) {
+					return {upgrade: true, connectionID: upgrade.connectionID};
+				}
+				return response!;
+			} catch (err) {
+				// If upgradeWebSocket() was called but the handler then threw,
+				// clean up the phantom client registration
+				if (upgradedClientId.length > 0) {
+					clients.removeWebSocketClient(upgradedClientId[0]);
+				}
+				throw err;
 			}
-			return response!;
 		},
 		setWebSocketHandlers(handlers: {
 			send: (connectionID: string, data: string | ArrayBuffer) => void;

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -1185,14 +1185,13 @@ export class ShovelClients implements Clients {
 	async matchAll<T extends ClientQueryOptions>(
 		options?: T,
 	): Promise<readonly (T["type"] extends "window" ? WindowClient : Client)[]> {
-		// WebSocket clients have type "worker", so include them in default/worker queries
-		const wsClients = [...this.#websocketClients.values()];
 		if ((options as any)?.type === "websocket") {
-			return wsClients as any;
+			return [...this.#websocketClients.values()] as any;
 		}
-		if (!options?.type || options.type === "worker" || options.type === "all") {
-			return wsClients as any;
+		if (options?.type === "all") {
+			return [...this.#websocketClients.values()] as any;
 		}
+		// Default (no type) returns window clients per spec — empty in server context
 		return [] as readonly (T["type"] extends "window"
 			? WindowClient
 			: Client)[];

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -1692,6 +1692,7 @@ export function createDirectModePool(
 	registration: ShovelServiceWorkerRegistration,
 	clients: ShovelClients,
 ) {
+	const logger = getLogger(["shovel", "platform"]);
 	let sendCallback:
 		| ((connectionID: string, data: string | ArrayBuffer) => void)
 		| null = null;
@@ -1731,7 +1732,11 @@ export function createDirectModePool(
 		sendWebSocketMessage(connectionID: string, data: string | ArrayBuffer) {
 			const client = clients.getWebSocketClient(connectionID);
 			if (client) {
-				dispatchWebSocketMessage(registration, client, data);
+				dispatchWebSocketMessage(registration, client, data).catch((err) => {
+					logger.error("WebSocket message dispatch failed: {error}", {
+						error: err,
+					});
+				});
 			}
 		},
 		sendWebSocketClose(
@@ -1743,7 +1748,17 @@ export function createDirectModePool(
 			const client = clients.getWebSocketClient(connectionID);
 			if (client) {
 				clients.removeWebSocketClient(connectionID);
-				dispatchWebSocketClose(registration, client, code, reason, wasClean);
+				dispatchWebSocketClose(
+					registration,
+					client,
+					code,
+					reason,
+					wasClean,
+				).catch((err) => {
+					logger.error("WebSocket close dispatch failed: {error}", {
+						error: err,
+					});
+				});
 			}
 		},
 	};

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -1185,8 +1185,13 @@ export class ShovelClients implements Clients {
 	async matchAll<T extends ClientQueryOptions>(
 		options?: T,
 	): Promise<readonly (T["type"] extends "window" ? WindowClient : Client)[]> {
+		// WebSocket clients have type "worker", so include them in default/worker queries
+		const wsClients = [...this.#websocketClients.values()];
 		if ((options as any)?.type === "websocket") {
-			return [...this.#websocketClients.values()] as any;
+			return wsClients as any;
+		}
+		if (!options?.type || options.type === "worker" || options.type === "all") {
+			return wsClients as any;
 		}
 		return [] as readonly (T["type"] extends "window"
 			? WindowClient

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -660,7 +660,7 @@ export function createDatabaseFactory(
 const SERVICE_WORKER_EVENTS = ["fetch", "install", "activate"] as const;
 
 /** Shovel extension event types dispatched on the registration */
-const SHOVEL_EVENTS = ["websocketmessage", "websocketclose"] as const;
+const SHOVEL_EVENTS = ["wsmessage", "wsclose"] as const;
 
 function isRegistrationEvent(type: string): boolean {
 	return (
@@ -1134,7 +1134,7 @@ export class WebSocketMessageEvent extends ShovelExtendableEvent {
 	readonly data: string | ArrayBuffer;
 
 	constructor(source: ShovelWebSocketClient, data: string | ArrayBuffer) {
-		super("websocketmessage");
+		super("wsmessage");
 		this.source = source;
 		this.data = data;
 	}
@@ -1155,7 +1155,7 @@ export class WebSocketCloseEvent extends ShovelExtendableEvent {
 		reason: string,
 		wasClean: boolean,
 	) {
-		super("websocketclose");
+		super("wsclose");
 		this.source = source;
 		this.code = code;
 		this.reason = reason;

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -1044,20 +1044,19 @@ export class ShovelWindowClient extends ShovelClient implements WindowClient {
 // WebSocket Events (Shovel extensions)
 // ============================================================================
 
-/** Module-level relay for WebSocket send/close (set by startWorkerMessageLoop or platform code) */
-let wsRelay: {
+interface WebSocketRelay {
 	send: (connectionID: string, data: string | ArrayBuffer) => void;
 	close: (connectionID: string, code?: number, reason?: string) => void;
-} | null = null;
+}
+
+/** Module-level relay for WebSocket send/close (set by startWorkerMessageLoop) */
+let wsRelay: WebSocketRelay | null = null;
 
 /**
  * Set the relay functions for WebSocket message forwarding.
  * Called by startWorkerMessageLoop (multi-worker) or platform-specific direct mode code.
  */
-export function setWebSocketRelay(relay: {
-	send: (connectionID: string, data: string | ArrayBuffer) => void;
-	close: (connectionID: string, code?: number, reason?: string) => void;
-}): void {
+export function setWebSocketRelay(relay: WebSocketRelay): void {
 	wsRelay = relay;
 }
 
@@ -1070,30 +1069,44 @@ export function setWebSocketRelay(relay: {
 export class ShovelWebSocketClient extends ShovelClient {
 	/** Arbitrary user data attached during upgradeWebSocket(), persists across events */
 	data: any;
+	#relay: WebSocketRelay | null;
 
-	constructor(options: {id: string; url: string; data?: any}) {
+	constructor(options: {
+		id: string;
+		url: string;
+		data?: any;
+		relay?: WebSocketRelay | null;
+	}) {
 		super({...options, type: "worker"});
 		this.data = options.data;
+		this.#relay = options.relay ?? null;
+	}
+
+	/** @internal Bind this client to a platform relay */
+	setRelay(relay: WebSocketRelay): void {
+		this.#relay = relay;
 	}
 
 	/** Send a message to the connected WebSocket client */
 	send(data: string | ArrayBuffer): void {
-		if (!wsRelay) {
+		const relay = this.#relay ?? wsRelay;
+		if (!relay) {
 			throw new Error(
 				"WebSocket relay not initialized. send() can only be called inside a worker.",
 			);
 		}
-		wsRelay.send(this.id, data);
+		relay.send(this.id, data);
 	}
 
 	/** Close the WebSocket connection */
 	close(code?: number, reason?: string): void {
-		if (!wsRelay) {
+		const relay = this.#relay ?? wsRelay;
+		if (!relay) {
 			throw new Error(
 				"WebSocket relay not initialized. close() can only be called inside a worker.",
 			);
 		}
-		wsRelay.close(this.id, code, reason);
+		relay.close(this.id, code, reason);
 	}
 }
 
@@ -1699,16 +1712,14 @@ export function createDirectModePool(
 	let closeCallback:
 		| ((connectionID: string, code?: number, reason?: string) => void)
 		| null = null;
-
-	// Set up relay so ShovelWebSocketClient.send/close go to the real socket
-	setWebSocketRelay({
+	const relay: WebSocketRelay = {
 		send(connectionID: string, data: string | ArrayBuffer) {
 			sendCallback?.(connectionID, data);
 		},
 		close(connectionID: string, code?: number, reason?: string) {
 			closeCallback?.(connectionID, code, reason);
 		},
-	});
+	};
 
 	return {
 		async handleRequest(
@@ -1717,6 +1728,7 @@ export function createDirectModePool(
 			const {response, event} = await dispatchFetchEvent(registration, request);
 			const upgrade = event[kGetUpgradeResult]();
 			if (upgrade) {
+				upgrade.client.setRelay(relay);
 				clients.registerWebSocketClient(upgrade.client);
 				return {upgrade: true, connectionID: upgrade.connectionID};
 			}

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -913,6 +913,12 @@ export class ShovelFetchEvent
 	 * Must be called synchronously during fetch event dispatch.
 	 */
 	upgradeWebSocket(options?: {data?: any}): ShovelWebSocketClient {
+		if (this.#responded) {
+			throw new Error(
+				"Cannot upgradeWebSocket() after respondWith() or upgradeWebSocket() was already called",
+			);
+		}
+
 		const connectionID = crypto.randomUUID();
 		const client = new ShovelWebSocketClient({
 			id: connectionID,

--- a/packages/platform/test/cross-worker-cache.test.ts
+++ b/packages/platform/test/cross-worker-cache.test.ts
@@ -135,7 +135,7 @@ startWorkerMessageLoop(registration);
 				"http://localhost/cache-put?key=shared-key&value=shared-value",
 			),
 		);
-		expect(await putResponse.text()).toBe("cached: shared-key");
+		expect(await (putResponse as Response).text()).toBe("cached: shared-key");
 
 		// Get the value via another request (may go to worker 2)
 		// Make multiple requests to increase chance of hitting different worker
@@ -144,7 +144,7 @@ startWorkerMessageLoop(registration);
 			const getResponse = await pool.handleRequest(
 				new Request("http://localhost/cache-get?key=shared-key"),
 			);
-			const text = await getResponse.text();
+			const text = await (getResponse as Response).text();
 			if (text === "hit: shared-value") {
 				hitCount++;
 			}
@@ -167,7 +167,7 @@ startWorkerMessageLoop(registration);
 			const response = await pool.handleRequest(
 				new Request(`http://localhost/cache-get?key=key-${i}`),
 			);
-			const text = await response.text();
+			const text = await (response as Response).text();
 			expect(text).toBe(`hit: value-${i}`);
 		}
 	});
@@ -182,7 +182,7 @@ startWorkerMessageLoop(registration);
 		const beforeDelete = await pool.handleRequest(
 			new Request("http://localhost/cache-get?key=delete-test"),
 		);
-		expect(await beforeDelete.text()).toBe("hit: to-delete");
+		expect(await (beforeDelete as Response).text()).toBe("hit: to-delete");
 
 		// Delete via the cache API (need to add delete endpoint to worker)
 		// For now, just verify the sharing works for put/get

--- a/packages/platform/test/websocket.test.ts
+++ b/packages/platform/test/websocket.test.ts
@@ -85,6 +85,22 @@ describe("FetchEvent.upgradeWebSocket()", () => {
 		);
 	});
 
+	it("prevents upgradeWebSocket after respondWith", () => {
+		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		event.respondWith(new Response("already responded"));
+		expect(() => event.upgradeWebSocket()).toThrow(
+			"Cannot upgradeWebSocket() after respondWith() or upgradeWebSocket() was already called",
+		);
+	});
+
+	it("prevents double upgradeWebSocket", () => {
+		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		event.upgradeWebSocket();
+		expect(() => event.upgradeWebSocket()).toThrow(
+			"Cannot upgradeWebSocket() after respondWith() or upgradeWebSocket() was already called",
+		);
+	});
+
 	it("getResponse returns null after upgrade", () => {
 		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
 		event.upgradeWebSocket();

--- a/packages/platform/test/websocket.test.ts
+++ b/packages/platform/test/websocket.test.ts
@@ -39,20 +39,26 @@ import * as esbuild from "esbuild";
 
 describe("FetchEvent.upgradeWebSocket()", () => {
 	it("returns a ShovelWebSocketClient", () => {
-		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		const event = new ShovelFetchEvent(
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
+		);
 		const client = event.upgradeWebSocket();
 		expect(client).toBeInstanceOf(ShovelWebSocketClient);
 	});
 
 	it("sets responded to true", () => {
-		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		const event = new ShovelFetchEvent(
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
+		);
 		expect(event.hasResponded()).toBe(false);
 		event.upgradeWebSocket();
 		expect(event.hasResponded()).toBe(true);
 	});
 
 	it("sets upgrade result accessible via kGetUpgradeResult", () => {
-		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		const event = new ShovelFetchEvent(
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
+		);
 		expect(event[kGetUpgradeResult]()).toBeNull();
 
 		const client = event.upgradeWebSocket();
@@ -63,7 +69,9 @@ describe("FetchEvent.upgradeWebSocket()", () => {
 	});
 
 	it("assigns a UUID as connectionID", () => {
-		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		const event = new ShovelFetchEvent(
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
+		);
 		const client = event.upgradeWebSocket();
 		// UUID v4 format
 		expect(client.id).toMatch(
@@ -72,13 +80,17 @@ describe("FetchEvent.upgradeWebSocket()", () => {
 	});
 
 	it("attaches user data to client", () => {
-		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		const event = new ShovelFetchEvent(
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
+		);
 		const client = event.upgradeWebSocket({data: {room: "lobby"}});
 		expect(client.data).toEqual({room: "lobby"});
 	});
 
 	it("prevents respondWith after upgradeWebSocket", () => {
-		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		const event = new ShovelFetchEvent(
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
+		);
 		event.upgradeWebSocket();
 		expect(() => event.respondWith(new Response("nope"))).toThrow(
 			"respondWith() already called",
@@ -86,7 +98,9 @@ describe("FetchEvent.upgradeWebSocket()", () => {
 	});
 
 	it("prevents upgradeWebSocket after respondWith", () => {
-		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		const event = new ShovelFetchEvent(
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
+		);
 		event.respondWith(new Response("already responded"));
 		expect(() => event.upgradeWebSocket()).toThrow(
 			"Cannot upgradeWebSocket() after respondWith() or upgradeWebSocket() was already called",
@@ -94,7 +108,9 @@ describe("FetchEvent.upgradeWebSocket()", () => {
 	});
 
 	it("prevents double upgradeWebSocket", () => {
-		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		const event = new ShovelFetchEvent(
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
+		);
 		event.upgradeWebSocket();
 		expect(() => event.upgradeWebSocket()).toThrow(
 			"Cannot upgradeWebSocket() after respondWith() or upgradeWebSocket() was already called",
@@ -102,9 +118,18 @@ describe("FetchEvent.upgradeWebSocket()", () => {
 	});
 
 	it("getResponse returns null after upgrade", () => {
-		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		const event = new ShovelFetchEvent(
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
+		);
 		event.upgradeWebSocket();
 		expect(event.getResponse()).toBeNull();
+	});
+
+	it("throws on non-WebSocket request", () => {
+		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		expect(() => event.upgradeWebSocket()).toThrow(
+			"Cannot upgradeWebSocket() on a request without Upgrade: websocket header",
+		);
 	});
 });
 
@@ -366,7 +391,7 @@ describe("WebSocket event dispatch", () => {
 
 		const {response, event} = await dispatchFetchEvent(
 			registration,
-			new Request("http://localhost/ws"),
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
 		);
 
 		expect(response).toBeNull();
@@ -423,7 +448,7 @@ describe("createDirectModePool", () => {
 
 		// Upgrade request returns WebSocketUpgradeResult
 		const wsResult = await pool.handleRequest(
-			new Request("http://localhost/ws"),
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
 		);
 		expect("upgrade" in wsResult).toBe(true);
 		expect((wsResult as any).upgrade).toBe(true);
@@ -466,7 +491,9 @@ describe("createDirectModePool", () => {
 		});
 
 		// Perform upgrade
-		const result = await pool.handleRequest(new Request("http://localhost/ws"));
+		const result = await pool.handleRequest(
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
+		);
 		const connectionID = (result as any).connectionID;
 
 		// Simulate incoming WebSocket message → should trigger echo
@@ -530,10 +557,10 @@ describe("createDirectModePool", () => {
 		});
 
 		const resultOne = await poolOne.handleRequest(
-			new Request("http://localhost/ws"),
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
 		);
 		const resultTwo = await poolTwo.handleRequest(
-			new Request("http://localhost/ws"),
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
 		);
 
 		const connectionOne = (resultOne as any).connectionID;
@@ -630,7 +657,9 @@ startWorkerMessageLoop({registration});
 	});
 
 	it("returns WebSocketUpgradeResult for upgrade requests", async () => {
-		const result = await pool.handleRequest(new Request("http://localhost/ws"));
+		const result = await pool.handleRequest(
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
+		);
 		expect("upgrade" in result).toBe(true);
 		expect((result as any).upgrade).toBe(true);
 		expect((result as any).connectionID).toMatch(
@@ -649,7 +678,9 @@ startWorkerMessageLoop({registration});
 		});
 
 		// Upgrade
-		const result = await pool.handleRequest(new Request("http://localhost/ws"));
+		const result = await pool.handleRequest(
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
+		);
 		const connectionID = (result as any).connectionID;
 
 		// Send message → worker echoes it back
@@ -673,7 +704,9 @@ startWorkerMessageLoop({registration});
 			close() {},
 		});
 
-		const result = await pool.handleRequest(new Request("http://localhost/ws"));
+		const result = await pool.handleRequest(
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
+		);
 		const connectionID = (result as any).connectionID;
 
 		// Send binary data
@@ -699,10 +732,10 @@ startWorkerMessageLoop({registration});
 
 		// Open two connections
 		const result1 = await pool.handleRequest(
-			new Request("http://localhost/ws"),
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
 		);
 		const result2 = await pool.handleRequest(
-			new Request("http://localhost/ws"),
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
 		);
 		const id1 = (result1 as any).connectionID;
 		const id2 = (result2 as any).connectionID;

--- a/packages/platform/test/websocket.test.ts
+++ b/packages/platform/test/websocket.test.ts
@@ -484,6 +484,71 @@ describe("createDirectModePool", () => {
 		// Simulate close
 		pool.sendWebSocketClose(connectionID, 1000, "bye", true);
 	});
+
+	it("keeps direct-mode relays isolated per pool", async () => {
+		const registrationOne = new ShovelServiceWorkerRegistration();
+		const clientsOne = new ShovelClients();
+		const sentOne: Array<{id: string; data: string | ArrayBuffer}> = [];
+
+		registrationOne.addEventListener("websocketmessage", ((
+			event: WebSocketMessageEvent,
+		) => {
+			event.source.send(`one:${event.data}`);
+		}) as EventListener);
+		registrationOne.addEventListener("fetch", ((event: FetchEvent) => {
+			event.upgradeWebSocket();
+		}) as EventListener);
+
+		const registrationTwo = new ShovelServiceWorkerRegistration();
+		const clientsTwo = new ShovelClients();
+		const sentTwo: Array<{id: string; data: string | ArrayBuffer}> = [];
+
+		registrationTwo.addEventListener("websocketmessage", ((
+			event: WebSocketMessageEvent,
+		) => {
+			event.source.send(`two:${event.data}`);
+		}) as EventListener);
+		registrationTwo.addEventListener("fetch", ((event: FetchEvent) => {
+			event.upgradeWebSocket();
+		}) as EventListener);
+
+		await runLifecycle(registrationOne);
+		await runLifecycle(registrationTwo);
+
+		const poolOne = createDirectModePool(registrationOne, clientsOne);
+		poolOne.setWebSocketHandlers({
+			send(id, data) {
+				sentOne.push({id, data});
+			},
+			close() {},
+		});
+
+		const poolTwo = createDirectModePool(registrationTwo, clientsTwo);
+		poolTwo.setWebSocketHandlers({
+			send(id, data) {
+				sentTwo.push({id, data});
+			},
+			close() {},
+		});
+
+		const resultOne = await poolOne.handleRequest(
+			new Request("http://localhost/ws"),
+		);
+		const resultTwo = await poolTwo.handleRequest(
+			new Request("http://localhost/ws"),
+		);
+
+		const connectionOne = (resultOne as any).connectionID;
+		const connectionTwo = (resultTwo as any).connectionID;
+
+		poolOne.sendWebSocketMessage(connectionOne, "alpha");
+		poolTwo.sendWebSocketMessage(connectionTwo, "beta");
+
+		await new Promise((r) => setTimeout(r, 10));
+
+		expect(sentOne).toEqual([{id: connectionOne, data: "one:alpha"}]);
+		expect(sentTwo).toEqual([{id: connectionTwo, data: "two:beta"}]);
+	});
 });
 
 // ============================================================================

--- a/packages/platform/test/websocket.test.ts
+++ b/packages/platform/test/websocket.test.ts
@@ -577,6 +577,147 @@ describe("createDirectModePool", () => {
 });
 
 // ============================================================================
+// Regression: non-cloneable client.data must not break pool upgrade
+// ============================================================================
+
+describe("non-cloneable client.data in pool mode", () => {
+	let pool: ServiceWorkerPool;
+	let tempDir: string;
+
+	beforeAll(async () => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ws-clone-test-"));
+
+		const currentDir = path.dirname(fileURLToPath(import.meta.url));
+		const nodeModulesSource = path.resolve(currentDir, "../../../node_modules");
+		fs.symlinkSync(
+			nodeModulesSource,
+			path.join(tempDir, "node_modules"),
+			"dir",
+		);
+
+		const workerSourcePath = path.join(tempDir, "ws-nonclone-worker.ts");
+		fs.writeFileSync(
+			workerSourcePath,
+			`
+import {initWorkerRuntime, runLifecycle, startWorkerMessageLoop} from "@b9g/platform/runtime";
+
+const {registration} = await initWorkerRuntime({config: {}});
+
+self.addEventListener("fetch", (event) => {
+	// Store a function in client.data — not structured-cloneable
+	event.upgradeWebSocket({data: {handler: () => "not cloneable", symbol: Symbol("x")}});
+});
+
+self.addEventListener("wsmessage", (event) => {
+	// Verify the non-cloneable data survived in-worker
+	const hasHandler = typeof event.source.data?.handler === "function";
+	event.source.send(hasHandler ? "ok" : "missing");
+});
+
+await runLifecycle(registration);
+startWorkerMessageLoop({registration});
+`,
+		);
+
+		const bundledPath = path.join(tempDir, "ws-nonclone-worker.js");
+		await esbuild.build({
+			entryPoints: [workerSourcePath],
+			bundle: true,
+			outfile: bundledPath,
+			format: "esm",
+			platform: "node",
+			target: "esnext",
+			external: ["node:*", "bun:*"],
+		});
+
+		pool = new ServiceWorkerPool(
+			{workerCount: 1, requestTimeout: 5000},
+			bundledPath,
+		);
+		await pool.init();
+	});
+
+	afterAll(async () => {
+		if (pool) await pool.terminate();
+		if (tempDir) fs.rmSync(tempDir, {recursive: true, force: true});
+	});
+
+	it("upgrade succeeds with non-cloneable client.data", async () => {
+		const sent: Array<{id: string; data: string | ArrayBuffer}> = [];
+
+		pool.setWebSocketHandlers({
+			send(id, data) {
+				sent.push({id, data});
+			},
+			close() {},
+		});
+
+		// This would throw DataCloneError if client.data was passed through postMessage
+		const result = await pool.handleRequest(
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
+		);
+		expect("upgrade" in result).toBe(true);
+
+		// Verify the worker kept the non-cloneable data locally
+		pool.sendWebSocketMessage((result as any).connectionID, "ping");
+		await new Promise((r) => setTimeout(r, 100));
+
+		expect(sent.length).toBe(1);
+		expect(sent[0].data).toBe("ok");
+	});
+});
+
+// Regression: close during upgrade handler must fire wsclose event
+// ============================================================================
+
+describe("close during upgrade in direct mode", () => {
+	it("fires wsclose when handler closes socket immediately after upgrade", async () => {
+		const registration = new ShovelServiceWorkerRegistration();
+		const clients = new ShovelClients();
+		const closedIds: string[] = [];
+
+		registration.addEventListener("fetch", ((event: FetchEvent) => {
+			const client = event.upgradeWebSocket();
+			// Immediately close — simulates rejecting a connection after upgrade
+			client.close(4000, "rejected");
+		}) as EventListener);
+
+		registration.addEventListener("wsclose", ((event: WebSocketCloseEvent) => {
+			closedIds.push(event.source.id);
+		}) as EventListener);
+
+		await runLifecycle(registration);
+
+		const pool = createDirectModePool(registration, clients);
+		const closed: Array<{id: string; code: number; reason: string}> = [];
+
+		pool.setWebSocketHandlers({
+			send() {},
+			close(id, code, reason) {
+				closed.push({id, code: code ?? 1000, reason: reason ?? ""});
+				// Simulate the platform adapter calling sendWebSocketClose
+				pool.sendWebSocketClose(id, code ?? 1000, reason ?? "", true);
+			},
+		});
+
+		const result = await pool.handleRequest(
+			new Request("http://localhost/ws", {headers: {upgrade: "websocket"}}),
+		);
+		expect("upgrade" in result).toBe(true);
+
+		// Give dispatch queue time to process
+		await new Promise((r) => setTimeout(r, 50));
+
+		expect(closed.length).toBe(1);
+		expect(closed[0].code).toBe(4000);
+		expect(closed[0].reason).toBe("rejected");
+
+		// wsclose event should have fired
+		expect(closedIds.length).toBe(1);
+	});
+});
+
+// ============================================================================
 // Integration: ServiceWorkerPool WebSocket upgrade
 // ============================================================================
 

--- a/packages/platform/test/websocket.test.ts
+++ b/packages/platform/test/websocket.test.ts
@@ -1,0 +1,645 @@
+/**
+ * Unit and integration tests for WebSocket support
+ *
+ * Tests:
+ * - upgradeWebSocket() on ShovelFetchEvent
+ * - WebSocketMessageEvent / WebSocketCloseEvent construction and dispatch
+ * - ShovelWebSocketClient send/close via relay
+ * - ShovelClients WebSocket tracking
+ * - Pool-level WebSocket upgrade flow
+ */
+
+import {describe, it, expect, beforeAll, afterAll} from "bun:test";
+import {
+	ShovelServiceWorkerRegistration,
+	ShovelFetchEvent,
+	ShovelWebSocketClient,
+	WebSocketMessageEvent,
+	WebSocketCloseEvent,
+	ShovelClients,
+	kGetUpgradeResult,
+	dispatchRequest,
+	dispatchFetchEvent,
+	dispatchWebSocketMessage,
+	dispatchWebSocketClose,
+	runLifecycle,
+	setWebSocketRelay,
+	createDirectModePool,
+} from "../src/runtime.js";
+import {ServiceWorkerPool} from "../src/index.js";
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
+import {fileURLToPath} from "url";
+import * as esbuild from "esbuild";
+
+// ============================================================================
+// Unit Tests: ShovelFetchEvent.upgradeWebSocket()
+// ============================================================================
+
+describe("FetchEvent.upgradeWebSocket()", () => {
+	it("returns a ShovelWebSocketClient", () => {
+		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		const client = event.upgradeWebSocket();
+		expect(client).toBeInstanceOf(ShovelWebSocketClient);
+	});
+
+	it("sets responded to true", () => {
+		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		expect(event.hasResponded()).toBe(false);
+		event.upgradeWebSocket();
+		expect(event.hasResponded()).toBe(true);
+	});
+
+	it("sets upgrade result accessible via kGetUpgradeResult", () => {
+		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		expect(event[kGetUpgradeResult]()).toBeNull();
+
+		const client = event.upgradeWebSocket();
+		const result = event[kGetUpgradeResult]();
+		expect(result).not.toBeNull();
+		expect(result!.client).toBe(client);
+		expect(result!.connectionID).toBe(client.id);
+	});
+
+	it("assigns a UUID as connectionID", () => {
+		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		const client = event.upgradeWebSocket();
+		// UUID v4 format
+		expect(client.id).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+		);
+	});
+
+	it("attaches user data to client", () => {
+		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		const client = event.upgradeWebSocket({data: {room: "lobby"}});
+		expect(client.data).toEqual({room: "lobby"});
+	});
+
+	it("prevents respondWith after upgradeWebSocket", () => {
+		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		event.upgradeWebSocket();
+		expect(() => event.respondWith(new Response("nope"))).toThrow(
+			"respondWith() already called",
+		);
+	});
+
+	it("getResponse returns null after upgrade", () => {
+		const event = new ShovelFetchEvent(new Request("http://localhost/ws"));
+		event.upgradeWebSocket();
+		expect(event.getResponse()).toBeNull();
+	});
+});
+
+// ============================================================================
+// Unit Tests: WebSocket Event Classes
+// ============================================================================
+
+describe("WebSocketMessageEvent", () => {
+	it("has correct type, source, and data", () => {
+		const client = new ShovelWebSocketClient({
+			id: "test-id",
+			url: "http://localhost/ws",
+			data: null,
+		});
+		const event = new WebSocketMessageEvent(client, "hello");
+		expect(event.type).toBe("websocketmessage");
+		expect(event.source).toBe(client);
+		expect(event.data).toBe("hello");
+	});
+
+	it("supports ArrayBuffer data", () => {
+		const client = new ShovelWebSocketClient({
+			id: "test-id",
+			url: "http://localhost/ws",
+			data: null,
+		});
+		const buf = new ArrayBuffer(4);
+		const event = new WebSocketMessageEvent(client, buf);
+		expect(event.data).toBe(buf);
+	});
+});
+
+describe("WebSocketCloseEvent", () => {
+	it("has correct type and properties", () => {
+		const client = new ShovelWebSocketClient({
+			id: "test-id",
+			url: "http://localhost/ws",
+			data: null,
+		});
+		const event = new WebSocketCloseEvent(client, 1000, "Normal", true);
+		expect(event.type).toBe("websocketclose");
+		expect(event.source).toBe(client);
+		expect(event.code).toBe(1000);
+		expect(event.reason).toBe("Normal");
+		expect(event.wasClean).toBe(true);
+	});
+});
+
+// ============================================================================
+// Unit Tests: ShovelWebSocketClient
+// ============================================================================
+
+describe("ShovelWebSocketClient", () => {
+	it("exposes id, url, and data", () => {
+		const client = new ShovelWebSocketClient({
+			id: "abc-123",
+			url: "http://localhost/ws",
+			data: {foo: "bar"},
+		});
+		expect(client.id).toBe("abc-123");
+		expect(client.url).toBe("http://localhost/ws");
+		expect(client.data).toEqual({foo: "bar"});
+	});
+
+	it("send() throws without relay", () => {
+		const client = new ShovelWebSocketClient({
+			id: "abc-123",
+			url: "http://localhost/ws",
+			data: null,
+		});
+		expect(() => client.send("test")).toThrow(
+			"WebSocket relay not initialized",
+		);
+	});
+
+	it("close() throws without relay", () => {
+		const client = new ShovelWebSocketClient({
+			id: "abc-123",
+			url: "http://localhost/ws",
+			data: null,
+		});
+		expect(() => client.close()).toThrow("WebSocket relay not initialized");
+	});
+
+	it("send() and close() work through relay", () => {
+		const sent: Array<{id: string; data: string | ArrayBuffer}> = [];
+		const closed: Array<{id: string; code?: number; reason?: string}> = [];
+
+		setWebSocketRelay({
+			send(id, data) {
+				sent.push({id, data});
+			},
+			close(id, code, reason) {
+				closed.push({id, code, reason});
+			},
+		});
+
+		const client = new ShovelWebSocketClient({
+			id: "relay-test",
+			url: "http://localhost/ws",
+			data: null,
+		});
+
+		client.send("hello");
+		client.send("world");
+		client.close(1000, "done");
+
+		expect(sent).toEqual([
+			{id: "relay-test", data: "hello"},
+			{id: "relay-test", data: "world"},
+		]);
+		expect(closed).toEqual([{id: "relay-test", code: 1000, reason: "done"}]);
+
+		// Clean up relay
+		setWebSocketRelay({
+			send() {},
+			close() {},
+		});
+	});
+});
+
+// ============================================================================
+// Unit Tests: ShovelClients WebSocket tracking
+// ============================================================================
+
+describe("ShovelClients WebSocket tracking", () => {
+	it("registers and retrieves WebSocket clients", () => {
+		const clients = new ShovelClients();
+		const client = new ShovelWebSocketClient({
+			id: "ws-1",
+			url: "http://localhost/ws",
+			data: null,
+		});
+
+		clients.registerWebSocketClient(client);
+		expect(clients.getWebSocketClient("ws-1")).toBe(client);
+	});
+
+	it("removes WebSocket clients", () => {
+		const clients = new ShovelClients();
+		const client = new ShovelWebSocketClient({
+			id: "ws-1",
+			url: "http://localhost/ws",
+			data: null,
+		});
+
+		clients.registerWebSocketClient(client);
+		clients.removeWebSocketClient("ws-1");
+		expect(clients.getWebSocketClient("ws-1")).toBeUndefined();
+	});
+
+	it("get() returns WebSocket clients", async () => {
+		const clients = new ShovelClients();
+		const client = new ShovelWebSocketClient({
+			id: "ws-1",
+			url: "http://localhost/ws",
+			data: null,
+		});
+
+		clients.registerWebSocketClient(client);
+		const result = await clients.get("ws-1");
+		expect(result).toBe(client);
+	});
+
+	it("matchAll with type websocket returns WebSocket clients", async () => {
+		const clients = new ShovelClients();
+		const client1 = new ShovelWebSocketClient({
+			id: "ws-1",
+			url: "http://localhost/ws",
+			data: null,
+		});
+		const client2 = new ShovelWebSocketClient({
+			id: "ws-2",
+			url: "http://localhost/ws",
+			data: null,
+		});
+
+		clients.registerWebSocketClient(client1);
+		clients.registerWebSocketClient(client2);
+
+		const all = await clients.matchAll({type: "websocket"} as any);
+		expect(all.length).toBe(2);
+	});
+});
+
+// ============================================================================
+// Integration: Dispatch WebSocket events through registration
+// ============================================================================
+
+describe("WebSocket event dispatch", () => {
+	it("dispatches websocketmessage to registration listeners", async () => {
+		const registration = new ShovelServiceWorkerRegistration();
+		const received: Array<{data: string | ArrayBuffer; clientId: string}> = [];
+
+		registration.addEventListener("websocketmessage", ((
+			event: WebSocketMessageEvent,
+		) => {
+			received.push({data: event.data, clientId: event.source.id});
+		}) as EventListener);
+
+		const client = new ShovelWebSocketClient({
+			id: "dispatch-test",
+			url: "http://localhost/ws",
+			data: null,
+		});
+
+		await dispatchWebSocketMessage(registration, client, "hello");
+		await dispatchWebSocketMessage(registration, client, "world");
+
+		expect(received).toEqual([
+			{data: "hello", clientId: "dispatch-test"},
+			{data: "world", clientId: "dispatch-test"},
+		]);
+	});
+
+	it("dispatches websocketclose to registration listeners", async () => {
+		const registration = new ShovelServiceWorkerRegistration();
+		const received: Array<{
+			code: number;
+			reason: string;
+			wasClean: boolean;
+		}> = [];
+
+		registration.addEventListener("websocketclose", ((
+			event: WebSocketCloseEvent,
+		) => {
+			received.push({
+				code: event.code,
+				reason: event.reason,
+				wasClean: event.wasClean,
+			});
+		}) as EventListener);
+
+		const client = new ShovelWebSocketClient({
+			id: "close-test",
+			url: "http://localhost/ws",
+			data: null,
+		});
+
+		await dispatchWebSocketClose(
+			registration,
+			client,
+			1000,
+			"Normal closure",
+			true,
+		);
+
+		expect(received).toEqual([
+			{code: 1000, reason: "Normal closure", wasClean: true},
+		]);
+	});
+
+	it("upgradeWebSocket in fetch handler returns null response via dispatchFetchEvent", async () => {
+		const registration = new ShovelServiceWorkerRegistration();
+
+		registration.addEventListener("fetch", ((event: FetchEvent) => {
+			event.upgradeWebSocket({data: {test: true}});
+		}) as EventListener);
+
+		await runLifecycle(registration);
+
+		const {response, event} = await dispatchFetchEvent(
+			registration,
+			new Request("http://localhost/ws"),
+		);
+
+		expect(response).toBeNull();
+		const upgrade = event[kGetUpgradeResult]();
+		expect(upgrade).not.toBeNull();
+		expect(upgrade!.client.data).toEqual({test: true});
+	});
+
+	it("non-upgrade fetch still returns Response via dispatchRequest", async () => {
+		const registration = new ShovelServiceWorkerRegistration();
+
+		registration.addEventListener("fetch", ((event: FetchEvent) => {
+			event.respondWith(new Response("hello"));
+		}) as EventListener);
+
+		await runLifecycle(registration);
+
+		const response = await dispatchRequest(
+			registration,
+			new Request("http://localhost/hello"),
+		);
+		expect(await response.text()).toBe("hello");
+	});
+});
+
+// ============================================================================
+// Integration: createDirectModePool
+// ============================================================================
+
+describe("createDirectModePool", () => {
+	it("returns WebSocketUpgradeResult for upgrade requests", async () => {
+		const registration = new ShovelServiceWorkerRegistration();
+		const clients = new ShovelClients();
+
+		registration.addEventListener("fetch", ((event: FetchEvent) => {
+			const url = new URL(event.request.url);
+			if (url.pathname === "/ws") {
+				event.upgradeWebSocket({data: {room: "test"}});
+			} else {
+				event.respondWith(new Response("hello"));
+			}
+		}) as EventListener);
+
+		await runLifecycle(registration);
+
+		const pool = createDirectModePool(registration, clients);
+
+		// Normal request returns Response
+		const httpResult = await pool.handleRequest(
+			new Request("http://localhost/hello"),
+		);
+		expect(httpResult).toBeInstanceOf(Response);
+		expect(await (httpResult as Response).text()).toBe("hello");
+
+		// Upgrade request returns WebSocketUpgradeResult
+		const wsResult = await pool.handleRequest(
+			new Request("http://localhost/ws"),
+		);
+		expect("upgrade" in wsResult).toBe(true);
+		expect((wsResult as any).upgrade).toBe(true);
+		expect((wsResult as any).connectionID).toBeDefined();
+	});
+
+	it("relays send/close through WebSocket handlers", async () => {
+		const registration = new ShovelServiceWorkerRegistration();
+		const clients = new ShovelClients();
+		const sent: Array<{id: string; data: string | ArrayBuffer}> = [];
+		const closed: Array<{
+			id: string;
+			code?: number;
+			reason?: string;
+		}> = [];
+
+		// Track what the user's websocketmessage handler sends back
+		registration.addEventListener("websocketmessage", ((
+			event: WebSocketMessageEvent,
+		) => {
+			event.source.send(`Echo: ${event.data}`);
+		}) as EventListener);
+
+		registration.addEventListener("fetch", ((event: FetchEvent) => {
+			event.upgradeWebSocket();
+		}) as EventListener);
+
+		await runLifecycle(registration);
+
+		const pool = createDirectModePool(registration, clients);
+
+		// Wire up handlers (like the platform adapter would)
+		pool.setWebSocketHandlers({
+			send(id, data) {
+				sent.push({id, data});
+			},
+			close(id, code, reason) {
+				closed.push({id, code, reason});
+			},
+		});
+
+		// Perform upgrade
+		const result = await pool.handleRequest(new Request("http://localhost/ws"));
+		const connectionID = (result as any).connectionID;
+
+		// Simulate incoming WebSocket message → should trigger echo
+		pool.sendWebSocketMessage(connectionID, "hello");
+
+		// Give async dispatch time to complete
+		await new Promise((r) => setTimeout(r, 10));
+
+		expect(sent.length).toBe(1);
+		expect(sent[0].data).toBe("Echo: hello");
+		expect(sent[0].id).toBe(connectionID);
+
+		// Simulate close
+		pool.sendWebSocketClose(connectionID, 1000, "bye", true);
+	});
+});
+
+// ============================================================================
+// Integration: ServiceWorkerPool WebSocket upgrade
+// ============================================================================
+
+describe("ServiceWorkerPool WebSocket upgrade", () => {
+	let pool: ServiceWorkerPool;
+	let tempDir: string;
+
+	beforeAll(async () => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ws-pool-test-"));
+
+		const currentDir = path.dirname(fileURLToPath(import.meta.url));
+		const nodeModulesSource = path.resolve(currentDir, "../../../node_modules");
+		fs.symlinkSync(
+			nodeModulesSource,
+			path.join(tempDir, "node_modules"),
+			"dir",
+		);
+
+		const workerSourcePath = path.join(tempDir, "ws-worker.ts");
+		fs.writeFileSync(
+			workerSourcePath,
+			`
+import {initWorkerRuntime, runLifecycle, startWorkerMessageLoop} from "@b9g/platform/runtime";
+
+const {registration} = await initWorkerRuntime({config: {}});
+
+self.addEventListener("fetch", (event) => {
+	const url = new URL(event.request.url);
+	if (url.pathname === "/ws") {
+		const client = event.upgradeWebSocket({data: {echo: true}});
+		return;
+	}
+	event.respondWith(new Response("not a websocket"));
+});
+
+self.addEventListener("websocketmessage", (event) => {
+	event.source.send("Echo: " + event.data);
+});
+
+self.addEventListener("websocketclose", (event) => {
+	// no-op
+});
+
+await runLifecycle(registration);
+startWorkerMessageLoop({registration});
+`,
+		);
+
+		const bundledPath = path.join(tempDir, "ws-worker.js");
+		await esbuild.build({
+			entryPoints: [workerSourcePath],
+			bundle: true,
+			outfile: bundledPath,
+			format: "esm",
+			platform: "node",
+			target: "esnext",
+			external: ["node:*", "bun:*"],
+		});
+
+		pool = new ServiceWorkerPool(
+			{workerCount: 1, requestTimeout: 5000},
+			bundledPath,
+		);
+		await pool.init();
+	});
+
+	afterAll(async () => {
+		if (pool) await pool.terminate();
+		if (tempDir) fs.rmSync(tempDir, {recursive: true, force: true});
+	});
+
+	it("returns Response for non-upgrade requests", async () => {
+		const result = await pool.handleRequest(
+			new Request("http://localhost/hello"),
+		);
+		expect(result).toBeInstanceOf(Response);
+		expect(await (result as Response).text()).toBe("not a websocket");
+	});
+
+	it("returns WebSocketUpgradeResult for upgrade requests", async () => {
+		const result = await pool.handleRequest(new Request("http://localhost/ws"));
+		expect("upgrade" in result).toBe(true);
+		expect((result as any).upgrade).toBe(true);
+		expect((result as any).connectionID).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+		);
+	});
+
+	it("relays messages to worker and back", async () => {
+		const sent: Array<{id: string; data: string | ArrayBuffer}> = [];
+
+		pool.setWebSocketHandlers({
+			send(id, data) {
+				sent.push({id, data});
+			},
+			close() {},
+		});
+
+		// Upgrade
+		const result = await pool.handleRequest(new Request("http://localhost/ws"));
+		const connectionID = (result as any).connectionID;
+
+		// Send message → worker echoes it back
+		pool.sendWebSocketMessage(connectionID, "ping");
+
+		// Wait for the echo
+		await new Promise((r) => setTimeout(r, 100));
+
+		expect(sent.length).toBe(1);
+		expect(sent[0].id).toBe(connectionID);
+		expect(sent[0].data).toBe("Echo: ping");
+	});
+
+	it("handles binary messages", async () => {
+		const sent: Array<{id: string; data: string | ArrayBuffer}> = [];
+
+		pool.setWebSocketHandlers({
+			send(id, data) {
+				sent.push({id, data});
+			},
+			close() {},
+		});
+
+		const result = await pool.handleRequest(new Request("http://localhost/ws"));
+		const connectionID = (result as any).connectionID;
+
+		// Send binary data
+		const buf = new TextEncoder().encode("binary-test").buffer;
+		pool.sendWebSocketMessage(connectionID, buf as ArrayBuffer);
+
+		await new Promise((r) => setTimeout(r, 100));
+
+		// Worker echo handler calls .send("Echo: " + event.data)
+		// Since binary data gets toString'd, we expect something back
+		expect(sent.length).toBe(1);
+	});
+
+	it("handles multiple concurrent connections", async () => {
+		const sent: Array<{id: string; data: string | ArrayBuffer}> = [];
+
+		pool.setWebSocketHandlers({
+			send(id, data) {
+				sent.push({id, data});
+			},
+			close() {},
+		});
+
+		// Open two connections
+		const result1 = await pool.handleRequest(
+			new Request("http://localhost/ws"),
+		);
+		const result2 = await pool.handleRequest(
+			new Request("http://localhost/ws"),
+		);
+		const id1 = (result1 as any).connectionID;
+		const id2 = (result2 as any).connectionID;
+
+		expect(id1).not.toBe(id2);
+
+		// Send messages on both
+		pool.sendWebSocketMessage(id1, "from-1");
+		pool.sendWebSocketMessage(id2, "from-2");
+
+		await new Promise((r) => setTimeout(r, 100));
+
+		// Both should get echoed back
+		const msg1 = sent.find((s) => s.id === id1);
+		const msg2 = sent.find((s) => s.id === id2);
+		expect(msg1?.data).toBe("Echo: from-1");
+		expect(msg2?.data).toBe("Echo: from-2");
+	});
+});

--- a/packages/platform/test/websocket.test.ts
+++ b/packages/platform/test/websocket.test.ts
@@ -120,7 +120,7 @@ describe("WebSocketMessageEvent", () => {
 			data: null,
 		});
 		const event = new WebSocketMessageEvent(client, "hello");
-		expect(event.type).toBe("websocketmessage");
+		expect(event.type).toBe("wsmessage");
 		expect(event.source).toBe(client);
 		expect(event.data).toBe("hello");
 	});
@@ -145,7 +145,7 @@ describe("WebSocketCloseEvent", () => {
 			data: null,
 		});
 		const event = new WebSocketCloseEvent(client, 1000, "Normal", true);
-		expect(event.type).toBe("websocketclose");
+		expect(event.type).toBe("wsclose");
 		expect(event.source).toBe(client);
 		expect(event.code).toBe(1000);
 		expect(event.reason).toBe("Normal");
@@ -295,11 +295,11 @@ describe("ShovelClients WebSocket tracking", () => {
 // ============================================================================
 
 describe("WebSocket event dispatch", () => {
-	it("dispatches websocketmessage to registration listeners", async () => {
+	it("dispatches wsmessage to registration listeners", async () => {
 		const registration = new ShovelServiceWorkerRegistration();
 		const received: Array<{data: string | ArrayBuffer; clientId: string}> = [];
 
-		registration.addEventListener("websocketmessage", ((
+		registration.addEventListener("wsmessage", ((
 			event: WebSocketMessageEvent,
 		) => {
 			received.push({data: event.data, clientId: event.source.id});
@@ -320,7 +320,7 @@ describe("WebSocket event dispatch", () => {
 		]);
 	});
 
-	it("dispatches websocketclose to registration listeners", async () => {
+	it("dispatches wsclose to registration listeners", async () => {
 		const registration = new ShovelServiceWorkerRegistration();
 		const received: Array<{
 			code: number;
@@ -328,9 +328,7 @@ describe("WebSocket event dispatch", () => {
 			wasClean: boolean;
 		}> = [];
 
-		registration.addEventListener("websocketclose", ((
-			event: WebSocketCloseEvent,
-		) => {
+		registration.addEventListener("wsclose", ((event: WebSocketCloseEvent) => {
 			received.push({
 				code: event.code,
 				reason: event.reason,
@@ -442,8 +440,8 @@ describe("createDirectModePool", () => {
 			reason?: string;
 		}> = [];
 
-		// Track what the user's websocketmessage handler sends back
-		registration.addEventListener("websocketmessage", ((
+		// Track what the user's wsmessage handler sends back
+		registration.addEventListener("wsmessage", ((
 			event: WebSocketMessageEvent,
 		) => {
 			event.source.send(`Echo: ${event.data}`);
@@ -490,7 +488,7 @@ describe("createDirectModePool", () => {
 		const clientsOne = new ShovelClients();
 		const sentOne: Array<{id: string; data: string | ArrayBuffer}> = [];
 
-		registrationOne.addEventListener("websocketmessage", ((
+		registrationOne.addEventListener("wsmessage", ((
 			event: WebSocketMessageEvent,
 		) => {
 			event.source.send(`one:${event.data}`);
@@ -503,7 +501,7 @@ describe("createDirectModePool", () => {
 		const clientsTwo = new ShovelClients();
 		const sentTwo: Array<{id: string; data: string | ArrayBuffer}> = [];
 
-		registrationTwo.addEventListener("websocketmessage", ((
+		registrationTwo.addEventListener("wsmessage", ((
 			event: WebSocketMessageEvent,
 		) => {
 			event.source.send(`two:${event.data}`);
@@ -587,11 +585,11 @@ self.addEventListener("fetch", (event) => {
 	event.respondWith(new Response("not a websocket"));
 });
 
-self.addEventListener("websocketmessage", (event) => {
+self.addEventListener("wsmessage", (event) => {
 	event.source.send("Echo: " + event.data);
 });
 
-self.addEventListener("websocketclose", (event) => {
+self.addEventListener("wsclose", (event) => {
 	// no-op
 });
 

--- a/packages/platform/test/worker-logging.test.ts
+++ b/packages/platform/test/worker-logging.test.ts
@@ -81,7 +81,7 @@ describe("worker logging", () => {
 		const response = await pool.handleRequest(
 			new Request("http://localhost/test"),
 		);
-		expect(await response.text()).toBe("ok");
+		expect(await (response as Response).text()).toBe("ok");
 
 		await pool.terminate();
 	});
@@ -105,7 +105,7 @@ describe("worker logging", () => {
 		const response = await pool.handleRequest(
 			new Request("http://localhost/test"),
 		);
-		expect(await response.text()).toBe("debug-ok");
+		expect(await (response as Response).text()).toBe("debug-ok");
 
 		await pool.terminate();
 	});
@@ -129,7 +129,7 @@ describe("worker logging", () => {
 		const response = await pool.handleRequest(
 			new Request("http://localhost/test"),
 		);
-		expect(await response.text()).toBe("warning-ok");
+		expect(await (response as Response).text()).toBe("warning-ok");
 
 		await pool.terminate();
 	});
@@ -153,7 +153,7 @@ describe("worker logging", () => {
 		const response = await pool.handleRequest(
 			new Request("http://localhost/test"),
 		);
-		expect(await response.text()).toBe("category-ok");
+		expect(await (response as Response).text()).toBe("category-ok");
 
 		await pool.terminate();
 	});
@@ -177,7 +177,7 @@ describe("worker logging", () => {
 		const response = await pool.handleRequest(
 			new Request("http://localhost/test"),
 		);
-		expect(await response.text()).toBe("empty-categories-ok");
+		expect(await (response as Response).text()).toBe("empty-categories-ok");
 
 		await pool.terminate();
 	});
@@ -201,7 +201,7 @@ describe("worker logging", () => {
 		const response = await pool.handleRequest(
 			new Request("http://localhost/test"),
 		);
-		expect(await response.text()).toBe("only-categories-ok");
+		expect(await (response as Response).text()).toBe("only-categories-ok");
 
 		await pool.terminate();
 	});

--- a/test/cloudflare-build.test.js
+++ b/test/cloudflare-build.test.js
@@ -23,6 +23,12 @@ async function createMiniflare(options, retries = 3) {
 		let mf;
 		try {
 			mf = new Miniflare(options);
+			// Miniflare's constructor fires an async init (#initPromise) that
+			// can reject before we await .ready (e.g. workerd spawn ENOENT).
+			// The internal .catch() re-throws, creating an unhandled rejection
+			// that Bun's test runner treats as a test failure — before our
+			// try/catch ever sees it. Eagerly awaiting .ready in the same
+			// microtask prevents this by handling the rejection immediately.
 			await mf.ready;
 			return mf;
 		} catch (err) {

--- a/test/cloudflare-build.test.js
+++ b/test/cloudflare-build.test.js
@@ -14,6 +14,32 @@ import {copyFixtureToTemp, fileExists} from "./utils.js";
 const TIMEOUT = 10000;
 const MINIFLARE_TIMEOUT = 30000;
 
+/**
+ * Create a Miniflare instance with retry for flaky workerd spawns on CI.
+ */
+async function createMiniflare(options, retries = 3) {
+	let lastErr;
+	for (let i = 0; i < retries; i++) {
+		let mf;
+		try {
+			mf = new Miniflare(options);
+			await mf.ready;
+			return mf;
+		} catch (err) {
+			lastErr = err;
+			try {
+				if (mf) await mf.dispose();
+			} catch (_disposeErr) {
+				// ignore dispose errors
+			}
+			if (i < retries - 1) {
+				await new Promise((r) => setTimeout(r, 1000));
+			}
+		}
+	}
+	throw lastErr;
+}
+
 test(
 	"cloudflare build - basic ServiceWorker",
 	async () => {
@@ -151,14 +177,12 @@ test(
 
 			// Load and run the worker in Miniflare
 			// This will fail if setTimeout is called in global scope during lifecycle
-			mf = new Miniflare({
+			mf = await createMiniflare({
 				modules: true,
 				script,
 				compatibilityDate: "2024-09-23",
 				compatibilityFlags: ["nodejs_compat"],
 			});
-
-			await mf.ready;
 
 			// Send a request to the worker
 			const response = await mf.dispatchFetch("http://localhost/");
@@ -246,7 +270,7 @@ self.addEventListener("fetch", (event) => {
 			const workerPath = join(outDir, "server", "worker.js");
 			const script = await FS.readFile(workerPath, "utf8");
 
-			mf = new Miniflare({
+			mf = await createMiniflare({
 				modules: true,
 				script,
 				compatibilityDate: "2024-09-23",
@@ -257,8 +281,6 @@ self.addEventListener("fetch", (event) => {
 					routerConfig: {has_user_worker: true},
 				},
 			});
-
-			await mf.ready;
 
 			// Fetch the URL map from the worker
 			const response = await mf.dispatchFetch("http://localhost/");

--- a/test/e2e-direct-mode.test.js
+++ b/test/e2e-direct-mode.test.js
@@ -190,7 +190,7 @@ async function fetchWithRetry(url, retries = 30, delay = 100) {
 
 describe("build output: Node.js direct mode", () => {
 	test(
-		"prod worker.js contains dispatchRequest for direct mode path",
+		"prod worker.js contains createDirectModePool for direct mode path",
 		async () => {
 			const cleanup_paths = [];
 			try {
@@ -211,8 +211,8 @@ self.addEventListener("fetch", (event) => {
 					"utf8",
 				);
 
-				// Worker should contain dispatchRequest for direct mode path
-				expect(workerContent).toContain("dispatchRequest");
+				// Worker should contain createDirectModePool for direct mode path
+				expect(workerContent).toContain("createDirectModePool");
 
 				// Worker should contain the "direct mode" log message string
 				expect(workerContent).toContain("direct mode");
@@ -311,7 +311,7 @@ self.addEventListener("fetch", (event) => {
 				// message loop for multi-worker
 				expect(workerContent).toContain("startWorkerMessageLoop");
 				// and direct mode for single-worker
-				expect(workerContent).toContain("dispatchRequest");
+				expect(workerContent).toContain("createDirectModePool");
 			} finally {
 				await cleanup(cleanup_paths);
 			}

--- a/test/e2e-direct-mode.test.js
+++ b/test/e2e-direct-mode.test.js
@@ -368,7 +368,7 @@ describe("code generation: Node.js platform", () => {
 
 		// Should have direct mode variable and branching
 		expect(worker).toContain("directMode");
-		expect(worker).toContain("dispatchRequest");
+		expect(worker).toContain("createDirectModePool");
 		expect(worker).toContain("usePostMessage: !directMode");
 
 		// Should have both code paths


### PR DESCRIPTION
## Summary

- Adds `websocketmessage` and `websocketclose` as new ServiceWorker functional events (ExtendableEvent subclasses)
- `FetchEvent.upgradeWebSocket()` upgrades connections — no HTTP Response created (101 is invalid in Node.js)
- Pool returns typed `WebSocketUpgradeResult` instead of monkeypatched Response objects
- Node.js adapter uses `ws` package with lazy loading; Bun uses native `Bun.serve` WebSocket support
- `createDirectModePool()` provides pool-compatible interface for single-worker deployments
- Full TypeScript types in globals.d.ts (`WebSocketClient`, event types, `upgradeWebSocket` on FetchEvent)

## User-facing API

```js
self.addEventListener("fetch", (event) => {
  if (event.request.headers.get("upgrade") === "websocket") {
    event.upgradeWebSocket({ data: { room: "lobby" } });
    return;
  }
  event.respondWith(new Response("Hello"));
});

self.addEventListener("websocketmessage", (event) => {
  event.source.send(`Echo: ${event.data}`);
});

self.addEventListener("websocketclose", (event) => {
  console.log(`Closed: ${event.code} ${event.reason}`);
});
```

## Test plan

- [x] All 194 package tests pass
- [x] 24 build tests pass
- [x] 19 e2e direct mode tests pass
- [x] 17 e2e bundling tests pass
- [x] TypeScript clean across all 3 platform packages
- [x] ESLint clean
- [ ] Manual WebSocket echo server test
- [ ] Multi-worker WebSocket sticky routing test

🤖 Generated with [Claude Code](https://claude.com/claude-code)