### PR TITLE
chore: update @types/bun to 1.3.11

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "@b9g/router": "workspace:*",
         "@eslint/js": "^9.0.0",
         "@logtape/file": "^2.0.0",
-        "@types/bun": "^1.3.4",
+        "@types/bun": "^1.3.11",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^9.0.0",
@@ -253,7 +253,7 @@
     },
     "packages/platform-bun": {
       "name": "@b9g/platform-bun",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "@b9g/assets": "workspace:*",
         "@b9g/cache": "workspace:*",
@@ -831,7 +831,7 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.14", "", {}, "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA=="],
 
-    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -909,7 +909,7 @@
 
     "buffer-from": ["buffer-from@0.1.2", "", {}, "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="],
 
-    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -1390,8 +1390,6 @@
     "@aws-sdk/middleware-user-agent/@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.993.0", "", { "dependencies": { "@aws-sdk/types": "^3.973.1", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-endpoints": "^3.2.8", "tslib": "^2.6.2" } }, "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw=="],
 
     "@aws-sdk/nested-clients/@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.993.0", "", { "dependencies": { "@aws-sdk/types": "^3.973.1", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-endpoints": "^3.2.8", "tslib": "^2.6.2" } }, "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw=="],
-
-    "@b9g/admin/@b9g/crank": ["@b9g/crank@0.7.6", "", {}, "sha512-SVD3VsdIjISL757MUoDu7xX+fGFwelktDNMGSnfZW4Q9vQD5id9rpUQoOFEBjlDBp5iLEP0mepzURmx3lETPaQ=="],
 
     "@b9g/broadcastchannel-redis/@logtape/logtape": ["@logtape/logtape@1.3.7", "", {}, "sha512-YgF+q9op97oLLPwc7TcTNIllTArVtTwkwyKky6XVzAXQcBrvFXXtMuwJSryONAyOUSItrx994O/HABOrszZyFg=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@b9g/router": "workspace:*",
     "@eslint/js": "^9.0.0",
     "@logtape/file": "^2.0.0",
-    "@types/bun": "^1.3.4",
+    "@types/bun": "^1.3.11",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^9.0.0",

--- a/packages/filesystem-s3/src/index.ts
+++ b/packages/filesystem-s3/src/index.ts
@@ -315,7 +315,23 @@ export class S3FileSystemDirectoryHandle implements FileSystemDirectoryHandle {
 		return null;
 	}
 
-	async *entries(): AsyncIterableIterator<[string, FileSystemHandle]> {
+	// TS 5.6+ changed the async iterator return types on FileSystemDirectoryHandle
+	// to a branded type that async generators can't produce. The `any` return types
+	// let `implements` check all other methods while keeping runtime behavior correct.
+	[Symbol.asyncIterator](): any {
+		return this.entries();
+	}
+	entries(): any {
+		return this.#generateEntries();
+	}
+	keys(): any {
+		return this.#generateKeys();
+	}
+	values(): any {
+		return this.#generateValues();
+	}
+
+	async *#generateEntries() {
 		const listPrefix = this.#prefix ? `${this.#prefix}/` : "";
 
 		try {
@@ -378,13 +394,13 @@ export class S3FileSystemDirectoryHandle implements FileSystemDirectoryHandle {
 		}
 	}
 
-	async *keys(): AsyncIterableIterator<string> {
+	async *#generateKeys() {
 		for await (const [name] of this.entries()) {
 			yield name;
 		}
 	}
 
-	async *values(): AsyncIterableIterator<FileSystemHandle> {
+	async *#generateValues() {
 		for await (const [, handle] of this.entries()) {
 			yield handle;
 		}

--- a/packages/platform-cloudflare/src/directories.ts
+++ b/packages/platform-cloudflare/src/directories.ts
@@ -243,7 +243,20 @@ export class R2FileSystemDirectoryHandle implements FileSystemDirectoryHandle {
 		return null;
 	}
 
-	async *entries(): AsyncIterableIterator<[string, FileSystemHandle]> {
+	[Symbol.asyncIterator](): any {
+		return this.entries();
+	}
+	entries(): any {
+		return this.#generateEntries();
+	}
+	keys(): any {
+		return this.#generateKeys();
+	}
+	values(): any {
+		return this.#generateValues();
+	}
+
+	async *#generateEntries() {
 		const listPrefix = this.#prefix ? `${this.#prefix}/` : "";
 
 		try {
@@ -262,7 +275,7 @@ export class R2FileSystemDirectoryHandle implements FileSystemDirectoryHandle {
 						yield [
 							name,
 							new R2FileSystemFileHandle(this.#r2Bucket, object.key),
-						];
+						] as [string, FileSystemHandle];
 					}
 				}
 			}
@@ -276,7 +289,7 @@ export class R2FileSystemDirectoryHandle implements FileSystemDirectoryHandle {
 							this.#r2Bucket,
 							prefix.replace(/\/$/, ""),
 						),
-					];
+					] as [string, FileSystemHandle];
 				}
 			}
 		} catch (error) {
@@ -284,13 +297,13 @@ export class R2FileSystemDirectoryHandle implements FileSystemDirectoryHandle {
 		}
 	}
 
-	async *keys(): AsyncIterableIterator<string> {
+	async *#generateKeys() {
 		for await (const [name] of this.entries()) {
 			yield name;
 		}
 	}
 
-	async *values(): AsyncIterableIterator<FileSystemHandle> {
+	async *#generateValues() {
 		for await (const [, handle] of this.entries()) {
 			yield handle;
 		}
@@ -426,32 +439,29 @@ export class CFAssetsDirectoryHandle implements FileSystemDirectoryHandle {
 		return null;
 	}
 
-	// eslint-disable-next-line require-yield
-	async *entries(): AsyncIterableIterator<[string, FileSystemHandle]> {
+	[Symbol.asyncIterator](): any {
+		return this.entries();
+	}
+
+	entries(): any {
 		throw new DOMException(
 			"Directory listing not supported for ASSETS binding. Use an asset manifest for enumeration.",
 			"NotSupportedError",
 		);
 	}
 
-	// eslint-disable-next-line require-yield
-	async *keys(): AsyncIterableIterator<string> {
+	keys(): any {
 		throw new DOMException(
 			"Directory listing not supported for ASSETS binding",
 			"NotSupportedError",
 		);
 	}
 
-	// eslint-disable-next-line require-yield
-	async *values(): AsyncIterableIterator<FileSystemHandle> {
+	values(): any {
 		throw new DOMException(
 			"Directory listing not supported for ASSETS binding",
 			"NotSupportedError",
 		);
-	}
-
-	[Symbol.asyncIterator](): AsyncIterableIterator<[string, FileSystemHandle]> {
-		return this.entries();
 	}
 
 	isSameEntry(other: FileSystemHandle): Promise<boolean> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,
 		"noEmit": true,
+		"types": ["bun"],
 		"lib": ["ES2022", "WebWorker"],
 		"jsx": "react-jsx",
 		"jsxImportSource": "@b9g/crank"


### PR DESCRIPTION
## Summary

- Update `@types/bun` from ^1.3.4 to 1.3.11
- CI uses `bun-version: latest` which resolved to 1.3.11, causing type resolution failures with the older lockfile version

## Test plan

- [x] `tsc --noEmit` passes
- [x] Filesystem and platform tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)