### PR TITLE
fix(build): restore client asset minification in production

### DIFF
--- a/src/utils/bundler.ts
+++ b/src/utils/bundler.ts
@@ -289,7 +289,14 @@ export class ServerBundler {
 		// Build config from userBuildConfig (respects MODE from config/env)
 		const target = userBuildConfig?.target ?? "es2022";
 		const sourcemap = userBuildConfig?.sourcemap ?? (watch ? "inline" : false);
+		// Server bundle: minify is opt-in (unchanged).
 		const minify = userBuildConfig?.minify ?? false;
+		// Client assets (CSS, client JS) minify in production by default —
+		// restoring the pre-#68 behavior where the asset path was hardcoded to
+		// minify. An explicit build.minify still wins for both; dev/watch builds
+		// stay unminified so source is readable during development.
+		const assetMinify =
+			userBuildConfig?.minify ?? (!this.#options.development && !watch);
 		const treeShaking = userBuildConfig?.treeShaking ?? true;
 
 		// Build ESBuild entry points from platform entry points
@@ -321,7 +328,7 @@ export class ServerBundler {
 			assetsPlugin({
 				outDir: outputDir,
 				plugins: userPlugins,
-				minify,
+				minify: assetMinify,
 				jsx: jsxOptions.jsx,
 				jsxFactory: jsxOptions.jsxFactory,
 				jsxFragment: jsxOptions.jsxFragment,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1661,7 +1661,13 @@ export interface ProcessedLoggingConfig {
 /** Processed build config with defaults applied */
 export interface ProcessedBuildConfig {
 	target: string | string[];
-	minify: boolean;
+	/**
+	 * Undefined means "unset" — the bundler applies mode-aware defaults (server
+	 * bundle stays opt-in; client assets minify in production). An explicit
+	 * boolean overrides both. Do not collapse this to `false` at load time, or
+	 * "unset" becomes indistinguishable from "explicitly disabled".
+	 */
+	minify?: boolean;
 	sourcemap: boolean | "inline" | "external" | "linked";
 	treeShaking: boolean;
 	define: Record<string, string>;
@@ -1739,7 +1745,10 @@ export function loadConfig(cwd: string): ProcessedShovelConfig {
 		},
 		build: {
 			target: validated.build?.target ?? "es2022",
-			minify: validated.build?.minify ?? false,
+			// Preserve "unset" (undefined) so the bundler can apply mode-aware
+			// defaults; collapsing to false here would force production client
+			// assets unminified (regression from PR #68 / issue #67).
+			minify: validated.build?.minify,
 			sourcemap: validated.build?.sourcemap ?? false,
 			treeShaking: validated.build?.treeShaking ?? true,
 			define: validated.build?.define ?? {},


### PR DESCRIPTION
## Summary

Restores client asset (CSS/JS) minification in production builds. **P1 regression** found by a separate session while migrating the website to crankdown — unrelated to that migration.

PR #68 (issue #67) made the client asset path honor `build.minify`, but `build.minify` **defaults to `false`** — so the fix also flipped the default from the previous hardcoded `minify: true`, silently shipping **unminified** CSS/JS to production for any site that never set `build.minify`.

## Root cause

`config.ts` collapsed an unset `build.minify` to `false` at load time, so the bundler could not distinguish "unset" from "explicitly disabled" — and then passed that `false` into the assets plugin, defeating its own `?? true` default.

## Fix

- `ProcessedBuildConfig.minify` is now optional; config no longer collapses an unset value to `false`, preserving the signal.
- The bundler applies **two** defaults: the server bundle stays opt-in (`?? false`, unchanged), while client assets minify in production by default (`?? !development`). An explicit `build.minify` still overrides both; dev/watch builds stay unminified for readable source.

## Verification

End-to-end against `website/`, same dist CLI, the 3-line change as the only variable:

| | client CSS |
|---|---|
| without fix | **13,174 bytes** (unminified) |
| with fix | **10,656 bytes** (minified) |

Both figures match the original report exactly. Lint clean; `test/assets.test.ts` 29/29; no new failures in `test/build.test.js`.

## Blast radius / follow-ups

- Same bug affects **crank.js.org** and **revise.js.org** (identical `MODE=production shovel build` + caret shovel dep). A patch release (0.2.20) fixes all three.
- ⚠️ `main`'s typecheck is **already red** (`ShovelFetchEvent` missing `FetchEvent.upgradeWebSocket`) — pre-existing and unrelated to this PR, but its CI typecheck job will fail for that reason.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
