### PR TITLE
chore(release): v0.2.20 — restore client asset minification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Shovel will be documented in this file.
 
+## [0.2.20] - 2026-07-13
+
+### Bug Fixes
+
+- **Client asset minification restored in production** — PR [#68](https://github.com/bikeshaving/shovel/pull/68) (issue [#67](https://github.com/bikeshaving/shovel/issues/67)) made the client asset path honor `build.minify`, but that option defaults to `false` — so it silently stopped minifying CSS/JS in production for any site that never set it (shovel.js.org's client CSS grew from 10,656 to 13,174 bytes). Client assets now minify in production by default again; an explicit `build.minify` still overrides both paths, and the server bundle stays opt-in. ([PR #93](https://github.com/bikeshaving/shovel/pull/93))
+
 ## [0.2.19] - 2026-03-17
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b9g/shovel",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "ServiceWorker-first universal deployment platform. Write ServiceWorker apps once, deploy anywhere (Node/Bun/Cloudflare). Registry-based multi-app orchestration.",
   "license": "MIT",
   "repository": {

--- a/src/utils/bundler.ts
+++ b/src/utils/bundler.ts
@@ -289,12 +289,8 @@ export class ServerBundler {
 		// Build config from userBuildConfig (respects MODE from config/env)
 		const target = userBuildConfig?.target ?? "es2022";
 		const sourcemap = userBuildConfig?.sourcemap ?? (watch ? "inline" : false);
-		// Server bundle: minify is opt-in (unchanged).
 		const minify = userBuildConfig?.minify ?? false;
-		// Client assets (CSS, client JS) minify in production by default —
-		// restoring the pre-#68 behavior where the asset path was hardcoded to
-		// minify. An explicit build.minify still wins for both; dev/watch builds
-		// stay unminified so source is readable during development.
+		// Client assets minify in production by default (server bundle stays opt-in).
 		const assetMinify =
 			userBuildConfig?.minify ?? (!this.#options.development && !watch);
 		const treeShaking = userBuildConfig?.treeShaking ?? true;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1661,12 +1661,7 @@ export interface ProcessedLoggingConfig {
 /** Processed build config with defaults applied */
 export interface ProcessedBuildConfig {
 	target: string | string[];
-	/**
-	 * Undefined means "unset" — the bundler applies mode-aware defaults (server
-	 * bundle stays opt-in; client assets minify in production). An explicit
-	 * boolean overrides both. Do not collapse this to `false` at load time, or
-	 * "unset" becomes indistinguishable from "explicitly disabled".
-	 */
+	/** Unset (undefined) lets the bundler apply mode-aware defaults; don't collapse it to a boolean. */
 	minify?: boolean;
 	sourcemap: boolean | "inline" | "external" | "linked";
 	treeShaking: boolean;
@@ -1745,9 +1740,8 @@ export function loadConfig(cwd: string): ProcessedShovelConfig {
 		},
 		build: {
 			target: validated.build?.target ?? "es2022",
-			// Preserve "unset" (undefined) so the bundler can apply mode-aware
-			// defaults; collapsing to false here would force production client
-			// assets unminified (regression from PR #68 / issue #67).
+			// Keep undefined when unset — collapsing to false here silently
+			// disables production client-asset minify (regression #68/#67).
 			minify: validated.build?.minify,
 			sourcemap: validated.build?.sourcemap ?? false,
 			treeShaking: validated.build?.treeShaking ?? true,


### PR DESCRIPTION
Release prep for **0.2.20**.

- Bumps `@b9g/shovel` 0.2.19 → 0.2.20.
- Changelogs the client-asset minify fix (#93).
- Trims that fix's comments to match surrounding density (keeps the single tripwire preventing a re-collapse of `build.minify` to `false`).

After merge: **`libuild publish`** to ship 0.2.20 to npm, which unblocks unpinning the website (#94's temporary `0.2.10` pin) and fixes crank.js.org / revise.js.org on their next install.

⚠️ CI typecheck will be red for the pre-existing #95 (`upgradeWebSocket`), unrelated to this PR.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)