### PR TITLE
fix(security): error verbosity must fail closed (#91, #100)

### DIFF
--- a/packages/platform-bun/src/index.ts
+++ b/packages/platform-bun/src/index.ts
@@ -301,7 +301,8 @@ export class BunPlatform {
 						});
 					}
 
-					const isDev = import.meta.env?.MODE !== "production";
+					// Fails closed: an unset MODE must not leak stack traces.
+					const isDev = import.meta.env?.MODE === "development";
 					return httpError.toResponse(isDev);
 				}
 			},

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -366,8 +366,8 @@ export class NodePlatform {
 					});
 				}
 
-				// import.meta.env is aliased to process.env for Node.js builds
-				const isDev = import.meta.env?.MODE !== "production";
+				// Fails closed: an unset MODE must not leak stack traces.
+				const isDev = import.meta.env?.MODE === "development";
 				const response = httpError.toResponse(isDev);
 
 				// Write response to Node.js res

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -663,12 +663,6 @@ function isServiceWorkerEvent(type: string): boolean {
 	return (SERVICE_WORKER_EVENTS as readonly string[]).includes(type);
 }
 
-// Set MODE from NODE_ENV for Vite compatibility
-// import.meta.env is shimmed to process.env via esbuild define on Node.js
-if (import.meta.env && !import.meta.env.MODE && import.meta.env.NODE_ENV) {
-	import.meta.env.MODE = import.meta.env.NODE_ENV;
-}
-
 // ============================================================================
 // AsyncContext for per-request cookieStore
 // ============================================================================

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -1052,8 +1052,9 @@ export class Router {
 	 * Uses HTTPError.toResponse() for consistent error formatting
 	 */
 	#createErrorResponse(error: Error): Response {
-		// Log the error in development for debugging
-		const isDev = import.meta.env?.MODE !== "production";
+		// Only be verbose when explicitly in development. An unset MODE must not
+		// leak stack traces to clients, so this fails closed.
+		const isDev = import.meta.env?.MODE === "development";
 		if (isDev && !isHTTPError(error)) {
 			logger.error`Unhandled error: ${error}`;
 		}

--- a/packages/router/test/router.test.ts
+++ b/packages/router/test/router.test.ts
@@ -843,9 +843,11 @@ describe("Router Integration", () => {
 
 		expect(executionOrder).toEqual(["middleware"]);
 		expect(response.status).toBe(404);
-		// Router uses HTTPError.toResponse() which generates HTML in dev mode
-		expect(response.headers.get("Content-Type")).toContain("text/html");
-		expect(await response.text()).toContain("404 Not Found");
+		// Error verbosity fails closed: with MODE unset (as here, unbundled), the
+		// router serves the minimal production response, never the stack-trace
+		// page. The verbose page requires MODE === "development" (#91, #100).
+		expect(response.headers.get("Content-Type")).toContain("text/plain");
+		expect(await response.text()).toContain("Not Found");
 	});
 });
 

--- a/src/utils/bundler.ts
+++ b/src/utils/bundler.ts
@@ -360,6 +360,10 @@ export class ServerBundler {
 			define: {
 				...(platformESBuildConfig.define ?? {}),
 				...(userBuildConfig?.define ?? {}),
+				// Error verbosity keys off MODE. Platforms without a populated
+				// import.meta.env (Cloudflare) would otherwise leave it undefined,
+				// so bake it in — the check then folds away at build time.
+				"import.meta.env.MODE": JSON.stringify(mode),
 				__SHOVEL_OUTDIR__: JSON.stringify(outputDir),
 				__SHOVEL_GIT__: JSON.stringify(getGitSHA(this.#projectRoot)),
 			},

--- a/test/error-verbosity.test.js
+++ b/test/error-verbosity.test.js
@@ -1,0 +1,93 @@
+import * as FS from "fs/promises";
+import {tmpdir} from "os";
+import {join} from "path";
+import {test, expect} from "bun:test";
+import {buildForProduction} from "../src/commands/build.js";
+import {ServerBundler} from "../src/utils/bundler.js";
+import {loadPlatformModule} from "../src/utils/platform.js";
+
+/**
+ * Error verbosity must fail closed (#91, #100).
+ *
+ * The verbose error page renders `error.stack` into the response body. It is
+ * gated on `import.meta.env.MODE === "development"`, and the bundler bakes MODE
+ * in at build time. Platforms with no populated import.meta.env (Cloudflare)
+ * left MODE undefined, and the old `MODE !== "production"` test then served
+ * stack traces to the public.
+ *
+ * These assert on the built server bundle: the gate must be constant-folded, so
+ * the verbose branch is statically unreachable in a production build. Bare
+ * `import.meta.env` reads are fine — that's the env-var accessor, not the gate.
+ */
+
+const TIMEOUT = 20000;
+
+const ENTRY = `
+import {Router} from "@b9g/router";
+const router = new Router();
+router.get("/boom", () => {
+	throw new Error("boom");
+});
+self.addEventListener("fetch", (event) => {
+	event.respondWith(router.fetch(event.request));
+});
+`;
+
+async function makeProject() {
+	const root = await FS.mkdtemp(join(tmpdir(), "error-verbosity-"));
+	const entrypoint = join(root, "entry.js");
+	await FS.writeFile(entrypoint, ENTRY);
+	return {root, entrypoint, outDir: join(root, "dist")};
+}
+
+async function readServerBundle(outDir) {
+	const serverDir = join(outDir, "server");
+	const files = await FS.readdir(serverDir);
+	const sources = await Promise.all(
+		files
+			.filter((f) => f.endsWith(".js"))
+			.map((f) => FS.readFile(join(serverDir, f), "utf8")),
+	);
+	return sources.join("\n");
+}
+
+for (const platform of ["cloudflare", "node", "bun"]) {
+	test(
+		`${platform} production build cannot render the verbose error page`,
+		async () => {
+			const {entrypoint, outDir} = await makeProject();
+			await buildForProduction({entrypoint, outDir, verbose: false, platform});
+			const bundle = await readServerBundle(outDir);
+
+			// The gate must be resolved at build time, not left to a
+			// possibly-undefined import.meta.env at the edge.
+			expect(bundle).not.toMatch(/import\.meta\.env\??\.MODE/);
+
+			// It collapses to a constant, so the verbose branch is unreachable.
+			expect(bundle).toMatch(/isDev\s*=\s*(false|!1)\b/);
+			expect(bundle).not.toMatch(/isDev\s*=\s*(true|!0)\b/);
+		},
+		TIMEOUT,
+	);
+}
+
+test(
+	"development build still renders the verbose error page",
+	async () => {
+		const {entrypoint, outDir} = await makeProject();
+		const platformModule = await loadPlatformModule("node");
+		const bundler = new ServerBundler({
+			entrypoint,
+			outDir,
+			platformModule,
+			platformESBuildConfig: platformModule.getESBuildConfig(),
+			development: true,
+		});
+		await bundler.build();
+		const bundle = await readServerBundle(outDir);
+
+		// Guards against over-correcting the fix into killing dev diagnostics.
+		expect(bundle).toMatch(/isDev\s*=\s*(true|!0)\b/);
+	},
+	TIMEOUT,
+);


### PR DESCRIPTION
Fixes #91. Fixes #100 (duplicate).

## The bug

`HTTPError.toResponse(isDev)` renders `error.stack` into the response body. It was gated on:

```js
const isDev = import.meta.env?.MODE !== "production";
```

**MODE was never set at build time.** On Cloudflare Workers `import.meta.env` isn't populated, so the gate saw `undefined`, concluded "not production", and served **stack traces to the public on every unhandled 4xx/5xx**.

It fails *open*: the safe path requires a signal that nothing was providing.

This is the same root cause as the CSS-minify regression (#67/#93) — a production signal that never got propagated.

## Scope: three gates, not one

#91 named the Cloudflare router path. There were three:

| | |
|---|---|
| `packages/router/src/index.ts:1056` | the Cloudflare leak in #91 |
| `packages/platform-node/src/index.ts:370` | leaked unless `NODE_ENV=production` happened to be set |
| `packages/platform-bun/src/index.ts:304` | same |

## The fix (defense in depth — either half closes the hole)

1. **Bake the signal in.** The bundler now emits an `import.meta.env.MODE` define — `"production"` for `shovel build`, `"development"` for `shovel develop`. MODE is now always present and correct on every platform.
2. **Fail closed.** All three gates now test `MODE === "development"` rather than `MODE !== "production"`, so an *unset* MODE yields the safe response. This also protects `@b9g/router` when consumed outside shovel's bundler.

Because the gate is now a build-time constant, **esbuild folds it and the verbose branch is statically unreachable in production bundles** (`const isDev = false`) — the stack-trace path isn't merely skipped, it's dead code.

Also drops the `NODE_ENV`→`MODE` runtime shim in `platform/runtime.ts`: obsolete now that MODE is baked in, and its assignment was what kept a literal `import.meta.env.MODE` alive in the Cloudflare bundle.

## Tests

New `test/error-verbosity.test.js` (4 tests) asserts on the **built** bundle:

- cloudflare / node / bun production builds: no residual `import.meta.env.MODE` gate; `isDev` folds to `false`; never `true`.
- a **development** build still folds `isDev = true` — guards against over-correcting into killing dev diagnostics.

**Validated against the vulnerable code**: with the fix reverted, the cloudflare assertion fails on the live `import.meta.env?.MODE` gate. It's a real regression test, not a vacuous one.

One existing router test asserted the *old fail-open behavior* (with MODE unset it expected the HTML stack-trace page). Updated to expect the minimal production response — that change is the fix working.

## Verification

- `test/error-verbosity.test.js`: 4/4
- router + http-errors: 109/109
- typecheck: exit 0 · lint: clean

## Suggested follow-up

Ship as **0.2.21**. This is a live information disclosure on the platform most likely to be public (Cloudflare + GitHub Pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmBa71chuLM78aDA4LKvf4