### PR TITLE
chore(release): v0.2.21 — error verbosity fails closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Shovel will be documented in this file.
 
+## [0.2.21] - 2026-07-14
+
+### Security
+
+- **Unhandled errors leaked stack traces to clients** — The debug error page renders `error.stack` into the response body, gated on `import.meta.env.MODE !== "production"`. `MODE` was never set at build time, so on platforms with no populated `import.meta.env` (Cloudflare Workers) the check saw `undefined`, concluded "not production", and served stack traces to the public on every unhandled 4xx/5xx. Node and Bun leaked the same way unless `NODE_ENV=production` happened to be set.
+
+  The build now bakes `MODE` into the bundle, and the error-verbosity gates test `MODE === "development"` so an unset mode **fails closed**. The verbose branch is now a build-time constant and gets eliminated from production bundles entirely. Sites deployed to Cloudflare should upgrade. (fixes [#91](https://github.com/bikeshaving/shovel/issues/91), [#100](https://github.com/bikeshaving/shovel/issues/100); [PR #102](https://github.com/bikeshaving/shovel/pull/102))
+
+  **Note:** `@b9g/router` used standalone (outside shovel's bundler) now returns the minimal production error response by default instead of the HTML debug page. Set `MODE=development` to restore verbose errors.
+
 ## [0.2.20] - 2026-07-13
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b9g/shovel",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "ServiceWorker-first universal deployment platform. Write ServiceWorker apps once, deploy anywhere (Node/Bun/Cloudflare). Registry-based multi-app orchestration.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Security patch release. Bumps `0.2.20` → `0.2.21` and adds the CHANGELOG entry for [#102](https://github.com/bikeshaving/shovel/pull/102) (already merged to main).

## What's in it

Only the security fix — deliberately **no features**. A patch people are being asked to apply urgently shouldn't carry unreviewed work, so #101 (directory snapshot) is held back for the next release.

**Unhandled errors leaked stack traces to clients.** The debug error page renders `error.stack` into the response body, gated on `MODE !== "production"`. MODE was never set at build time, so on Cloudflare (no populated `import.meta.env`) the gate saw `undefined`, concluded "not production", and served stack traces publicly on every unhandled 4xx/5xx. Node/Bun leaked the same way unless `NODE_ENV=production` was set.

Now: the build bakes MODE in, and the gates test `MODE === "development"` so an unset mode **fails closed**. The verbose branch is a build-time constant and gets dead-code-eliminated out of production bundles.

## Breaking-ish note (called out in the CHANGELOG)

`@b9g/router` used **standalone**, outside shovel's bundler, now returns the minimal production error response by default rather than the HTML debug page. Set `MODE=development` for verbose errors. This is the fix working as intended — the old default was the vulnerability — but it is a visible behavior change for direct router consumers.

## After merge

Publish `@b9g/shovel@0.2.21` to npm, then unpin the website.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmBa71chuLM78aDA4LKvf4