### PR TITLE
feat(cloudflare): directory enumeration over the ASSETS binding via the asset manifest

### DIFF
--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -95,7 +95,8 @@
       "types": "./dist/src/pubsub.d.ts",
       "import": "./dist/src/pubsub.js"
     },
-    "./cloudflare.d.ts": "./dist/src/cloudflare.d.ts"
+    "./cloudflare.d.ts": "./dist/src/cloudflare.d.ts",
+    "./shovel-assets.d.ts": "./dist/src/shovel-assets.d.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/platform-cloudflare/src/directories.ts
+++ b/packages/platform-cloudflare/src/directories.ts
@@ -483,12 +483,12 @@ export class CFAssetsDirectoryHandle implements FileSystemDirectoryHandle {
 	 * `shovel:assets`. Enumeration reads it and reports the direct children of
 	 * this directory's base path — files as file handles, and any deeper path
 	 * as a subdirectory (deduped).
+	 *
+	 * Returns `any` because the lib declares these as
+	 * FileSystemDirectoryHandleAsyncIterator, which an AsyncGenerator can't
+	 * satisfy (BuiltinIteratorReturn).
 	 */
-	async *entries(): AsyncGenerator<
-		[string, FileSystemHandle],
-		void,
-		undefined
-	> {
+	async *entries(): any {
 		const manifest = this.#manifest ?? (await getAssetManifest());
 		if (!manifest) {
 			throw new DOMException(
@@ -528,11 +528,11 @@ export class CFAssetsDirectoryHandle implements FileSystemDirectoryHandle {
 		}
 	}
 
-	async *keys(): AsyncGenerator<string, void, undefined> {
+	async *keys(): any {
 		for await (const [name] of this.entries()) yield name;
 	}
 
-	async *values(): AsyncGenerator<FileSystemHandle, void, undefined> {
+	async *values(): any {
 		for await (const [, handle] of this.entries()) yield handle;
 	}
 

--- a/packages/platform-cloudflare/src/directories.ts
+++ b/packages/platform-cloudflare/src/directories.ts
@@ -266,20 +266,28 @@ export class R2FileSystemDirectoryHandle implements FileSystemDirectoryHandle {
 		return null;
 	}
 
-	[Symbol.asyncIterator](): any {
+	[Symbol.asyncIterator](): AsyncIterableIterator<
+		[string, FileSystemFileHandle | FileSystemDirectoryHandle]
+	> {
 		return this.entries();
 	}
-	entries(): any {
+	entries(): AsyncIterableIterator<
+		[string, FileSystemFileHandle | FileSystemDirectoryHandle]
+	> {
 		return this.#generateEntries();
 	}
-	keys(): any {
+	keys(): AsyncIterableIterator<string> {
 		return this.#generateKeys();
 	}
-	values(): any {
+	values(): AsyncIterableIterator<
+		FileSystemFileHandle | FileSystemDirectoryHandle
+	> {
 		return this.#generateValues();
 	}
 
-	async *#generateEntries() {
+	async *#generateEntries(): AsyncIterableIterator<
+		[string, FileSystemFileHandle | FileSystemDirectoryHandle]
+	> {
 		const listPrefix = this.#prefix ? `${this.#prefix}/` : "";
 
 		try {
@@ -298,7 +306,7 @@ export class R2FileSystemDirectoryHandle implements FileSystemDirectoryHandle {
 						yield [
 							name,
 							new R2FileSystemFileHandle(this.#r2Bucket, object.key),
-						] as [string, FileSystemHandle];
+						] as [string, FileSystemFileHandle | FileSystemDirectoryHandle];
 					}
 				}
 			}
@@ -312,7 +320,7 @@ export class R2FileSystemDirectoryHandle implements FileSystemDirectoryHandle {
 							this.#r2Bucket,
 							prefix.replace(/\/$/, ""),
 						),
-					] as [string, FileSystemHandle];
+					] as [string, FileSystemFileHandle | FileSystemDirectoryHandle];
 				}
 			}
 		} catch (error) {
@@ -320,13 +328,15 @@ export class R2FileSystemDirectoryHandle implements FileSystemDirectoryHandle {
 		}
 	}
 
-	async *#generateKeys() {
+	async *#generateKeys(): AsyncIterableIterator<string> {
 		for await (const [name] of this.entries()) {
 			yield name;
 		}
 	}
 
-	async *#generateValues() {
+	async *#generateValues(): AsyncIterableIterator<
+		FileSystemFileHandle | FileSystemDirectoryHandle
+	> {
 		for await (const [, handle] of this.entries()) {
 			yield handle;
 		}
@@ -473,7 +483,9 @@ export class CFAssetsDirectoryHandle implements FileSystemDirectoryHandle {
 		return null;
 	}
 
-	[Symbol.asyncIterator](): any {
+	[Symbol.asyncIterator](): AsyncIterableIterator<
+		[string, FileSystemFileHandle | FileSystemDirectoryHandle]
+	> {
 		return this.entries();
 	}
 
@@ -483,12 +495,10 @@ export class CFAssetsDirectoryHandle implements FileSystemDirectoryHandle {
 	 * `shovel:assets`. Enumeration reads it and reports the direct children of
 	 * this directory's base path — files as file handles, and any deeper path
 	 * as a subdirectory (deduped).
-	 *
-	 * Returns `any` because the lib declares these as
-	 * FileSystemDirectoryHandleAsyncIterator, which an AsyncGenerator can't
-	 * satisfy (BuiltinIteratorReturn).
 	 */
-	async *entries(): any {
+	async *entries(): AsyncIterableIterator<
+		[string, FileSystemFileHandle | FileSystemDirectoryHandle]
+	> {
 		const manifest = this.#manifest ?? (await getAssetManifest());
 		if (!manifest) {
 			throw new DOMException(
@@ -528,11 +538,13 @@ export class CFAssetsDirectoryHandle implements FileSystemDirectoryHandle {
 		}
 	}
 
-	async *keys(): any {
+	async *keys(): AsyncIterableIterator<string> {
 		for await (const [name] of this.entries()) yield name;
 	}
 
-	async *values(): any {
+	async *values(): AsyncIterableIterator<
+		FileSystemFileHandle | FileSystemDirectoryHandle
+	> {
 		for await (const [, handle] of this.entries()) yield handle;
 	}
 

--- a/packages/platform-cloudflare/src/directories.ts
+++ b/packages/platform-cloudflare/src/directories.ts
@@ -15,6 +15,29 @@ import mime from "mime";
 import {getEnv} from "./variables.js";
 
 // ============================================================================
+// ASSET MANIFEST
+// ============================================================================
+
+/** The subset of the shovel:assets manifest that enumeration needs. */
+export interface AssetManifest {
+	assets: Record<string, {url?: string}>;
+}
+
+let manifestPromise: Promise<AssetManifest | null> | undefined;
+
+/**
+ * Load the asset manifest the build bundles into the worker.
+ *
+ * Resolves to null when it isn't there — the directory is usable outside a
+ * shovel build (reads go straight through the binding), just not enumerable.
+ */
+function getAssetManifest(): Promise<AssetManifest | null> {
+	return (manifestPromise ??= import("shovel:assets")
+		.then((mod) => (mod.default as AssetManifest) ?? null)
+		.catch(() => null));
+}
+
+// ============================================================================
 // R2 TYPES
 // ============================================================================
 
@@ -391,12 +414,19 @@ export class CFAssetsDirectoryHandle implements FileSystemDirectoryHandle {
 	readonly name: string;
 	#assets: CFAssetsBinding;
 	#basePath: string;
+	#manifest?: AssetManifest;
 
-	constructor(assets: CFAssetsBinding, basePath = "/") {
+	constructor(
+		assets: CFAssetsBinding,
+		basePath = "/",
+		/** Overrides the bundled shovel:assets manifest (used by tests). */
+		manifest?: AssetManifest,
+	) {
 		this.kind = "directory";
 		this.#assets = assets;
 		this.#basePath = basePath.endsWith("/") ? basePath : basePath + "/";
 		this.name = basePath.split("/").filter(Boolean).pop() || "assets";
+		this.#manifest = manifest;
 	}
 
 	async getFileHandle(
@@ -423,7 +453,11 @@ export class CFAssetsDirectoryHandle implements FileSystemDirectoryHandle {
 		name: string,
 		_options?: FileSystemGetDirectoryOptions,
 	): Promise<FileSystemDirectoryHandle> {
-		return new CFAssetsDirectoryHandle(this.#assets, this.#basePath + name);
+		return new CFAssetsDirectoryHandle(
+			this.#assets,
+			this.#basePath + name,
+			this.#manifest,
+		);
 	}
 
 	async removeEntry(
@@ -443,25 +477,63 @@ export class CFAssetsDirectoryHandle implements FileSystemDirectoryHandle {
 		return this.entries();
 	}
 
-	entries(): any {
-		throw new DOMException(
-			"Directory listing not supported for ASSETS binding. Use an asset manifest for enumeration.",
-			"NotSupportedError",
-		);
+	/**
+	 * The ASSETS binding has no list API, but the build already knows every
+	 * asset it emitted: the manifest is bundled into the worker as
+	 * `shovel:assets`. Enumeration reads it and reports the direct children of
+	 * this directory's base path — files as file handles, and any deeper path
+	 * as a subdirectory (deduped).
+	 */
+	async *entries(): AsyncGenerator<
+		[string, FileSystemHandle],
+		void,
+		undefined
+	> {
+		const manifest = this.#manifest ?? (await getAssetManifest());
+		if (!manifest) {
+			throw new DOMException(
+				"Directory listing for the ASSETS binding needs the shovel:assets " +
+					"manifest, which is not supported outside a shovel build.",
+				"NotSupportedError",
+			);
+		}
+
+		const seen = new Set<string>();
+		for (const entry of Object.values(manifest.assets)) {
+			if (typeof entry?.url !== "string") continue;
+			if (!entry.url.startsWith(this.#basePath)) continue;
+
+			const rest = entry.url.slice(this.#basePath.length);
+			if (!rest) continue;
+
+			const slash = rest.indexOf("/");
+			if (slash === -1) {
+				if (seen.has(rest)) continue;
+				seen.add(rest);
+				yield [rest, new CFAssetsFileHandle(this.#assets, entry.url, rest)];
+			} else {
+				// A deeper asset implies a subdirectory child.
+				const dir = rest.slice(0, slash);
+				if (seen.has(dir)) continue;
+				seen.add(dir);
+				yield [
+					dir,
+					new CFAssetsDirectoryHandle(
+						this.#assets,
+						this.#basePath + dir,
+						manifest,
+					),
+				];
+			}
+		}
 	}
 
-	keys(): any {
-		throw new DOMException(
-			"Directory listing not supported for ASSETS binding",
-			"NotSupportedError",
-		);
+	async *keys(): AsyncGenerator<string, void, undefined> {
+		for await (const [name] of this.entries()) yield name;
 	}
 
-	values(): any {
-		throw new DOMException(
-			"Directory listing not supported for ASSETS binding",
-			"NotSupportedError",
-		);
+	async *values(): AsyncGenerator<FileSystemHandle, void, undefined> {
+		for await (const [, handle] of this.entries()) yield handle;
 	}
 
 	isSameEntry(other: FileSystemHandle): Promise<boolean> {

--- a/packages/platform-cloudflare/src/shovel-assets.d.ts
+++ b/packages/platform-cloudflare/src/shovel-assets.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Type declarations for the shovel:assets virtual module.
+ * Resolved by esbuild at build time; absent outside a shovel build.
+ */
+declare module "shovel:assets" {
+	const manifest: {assets: Record<string, {url?: string}>};
+	export default manifest;
+}

--- a/packages/platform-cloudflare/test/filesystem-assets.test.ts
+++ b/packages/platform-cloudflare/test/filesystem-assets.test.ts
@@ -102,7 +102,10 @@ describe("CFAssetsDirectoryHandle", () => {
 		expect(fileHandle.createWritable()).rejects.toThrow("read-only");
 	});
 
-	test("entries() throws NotSupportedError", async () => {
+	// The ASSETS binding has no list API, so enumeration reads the asset
+	// manifest the build bundles into the worker. Without one there is nothing
+	// to list; with one, the directory enumerates like any other.
+	test("entries() throws NotSupportedError without a manifest", async () => {
 		const dir = new CFAssetsDirectoryHandle(assets, "/");
 
 		expect(async () => {
@@ -110,6 +113,58 @@ describe("CFAssetsDirectoryHandle", () => {
 				// Should not reach here
 			}
 		}).toThrow("not supported");
+	});
+
+	describe("enumeration via the asset manifest", () => {
+		const manifest = {
+			assets: {
+				"src/styles/style.css": {url: "/assets/style.abc123.css"},
+				"src/app.ts": {url: "/assets/app.def456.js"},
+				"src/index.html": {url: "/index.html"},
+			},
+		};
+
+		test("keys() lists the direct children of the base path", async () => {
+			const dir = new CFAssetsDirectoryHandle(assets, "/assets", manifest);
+			const names: string[] = [];
+			for await (const name of dir.keys()) names.push(name);
+			expect(names.sort()).toEqual(["app.def456.js", "style.abc123.css"]);
+		});
+
+		test("a deeper asset surfaces as a subdirectory, not a file", async () => {
+			const dir = new CFAssetsDirectoryHandle(assets, "/", manifest);
+			const entries: Array<[string, string]> = [];
+			for await (const [name, handle] of dir.entries()) {
+				entries.push([name, handle.kind]);
+			}
+			expect(entries.sort()).toEqual([
+				["assets", "directory"],
+				["index.html", "file"],
+			]);
+		});
+
+		test("values() yield handles that read real content", async () => {
+			const dir = new CFAssetsDirectoryHandle(assets, "/assets", manifest);
+			const byName = new Map<string, FileSystemFileHandle>();
+			for await (const handle of dir.values()) {
+				byName.set(handle.name, handle as FileSystemFileHandle);
+			}
+
+			const css = byName.get("style.abc123.css")!;
+			expect(await (await css.getFile()).text()).toBe("body { color: blue; }");
+		});
+
+		test("navigating into a subdirectory keeps it enumerable", async () => {
+			const root = new CFAssetsDirectoryHandle(assets, "/", manifest);
+			// getDirectoryHandle is typed to the DOM handle, which predates
+			// keys()/entries() — the concrete class has them.
+			const sub = (await root.getDirectoryHandle(
+				"assets",
+			)) as CFAssetsDirectoryHandle;
+			const names: string[] = [];
+			for await (const name of sub.keys()) names.push(name);
+			expect(names.sort()).toEqual(["app.def456.js", "style.abc123.css"]);
+		});
 	});
 
 	test("isSameEntry returns true for same path", async () => {

--- a/test/cloudflare-build.test.js
+++ b/test/cloudflare-build.test.js
@@ -287,3 +287,158 @@ self.addEventListener("fetch", (event) => {
 	},
 	MINIFLARE_TIMEOUT,
 );
+
+test(
+	"cloudflare build - directory enumeration over ASSETS via the bundled manifest",
+	async () => {
+		const tempDir = join(
+			(await import("os")).tmpdir(),
+			`shovel-cf-enum-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		await FS.mkdir(tempDir, {recursive: true});
+		let mf;
+
+		try {
+			// A content tree: a file and a subdirectory at the base path.
+			await FS.mkdir(join(tempDir, "content", "posts"), {recursive: true});
+			await FS.writeFile(join(tempDir, "content", "about.md"), "# About");
+			await FS.writeFile(
+				join(tempDir, "content", "posts", "first.md"),
+				"# First post",
+			);
+			await FS.writeFile(
+				join(tempDir, "content", "posts", "second.md"),
+				"# Second post",
+			);
+
+			// The real config story: a directory over the ASSETS binding. The
+			// glob import stages content/ into dist/public; the worker then
+			// enumerates it through self.directories with no injected manifest,
+			// so listing must go through the bundled shovel:assets module.
+			await FS.writeFile(
+				join(tempDir, "app.js"),
+				`
+import urls from "./content/**/*" with { assetBase: "/content/", assetName: "[name].[ext]" };
+
+self.addEventListener("fetch", (event) => {
+	event.respondWith(handle(event.request));
+});
+
+async function handle(request) {
+	const url = new URL(request.url);
+	const dir = await self.directories.open("content");
+	if (url.pathname === "/list") {
+		const listing = {};
+		for await (const [name, handle] of dir.entries()) {
+			listing[name] = handle.kind;
+		}
+		return Response.json({listing, staged: Object.keys(urls).length});
+	}
+	if (url.pathname === "/read-posts") {
+		const posts = await dir.getDirectoryHandle("posts");
+		const names = [];
+		for await (const name of posts.keys()) names.push(name);
+		names.sort();
+		const fileHandle = await posts.getFileHandle(names[0]);
+		const text = await (await fileHandle.getFile()).text();
+		return Response.json({names, text});
+	}
+	return new Response("not found", {status: 404});
+}
+`,
+			);
+
+			await FS.writeFile(
+				join(tempDir, "shovel.json"),
+				JSON.stringify({
+					directories: {
+						content: {
+							module: "@b9g/platform-cloudflare/directories",
+							export: "CloudflareAssetsDirectory",
+							path: "/content",
+						},
+					},
+				}),
+			);
+
+			await FS.writeFile(
+				join(tempDir, "package.json"),
+				JSON.stringify({name: "test-cf-enum", type: "module"}),
+			);
+
+			await FS.symlink(
+				join(process.cwd(), "node_modules"),
+				join(tempDir, "node_modules"),
+				"dir",
+			);
+
+			const outDir = join(tempDir, "dist");
+			const originalCwd = process.cwd();
+			process.chdir(tempDir);
+
+			try {
+				await buildForProduction({
+					entrypoint: join(tempDir, "app.js"),
+					outDir,
+					verbose: false,
+					platform: "cloudflare",
+				});
+			} finally {
+				process.chdir(originalCwd);
+			}
+
+			expect(
+				await fileExists(join(outDir, "public", "content", "about.md")),
+			).toBe(true);
+
+			const script = await FS.readFile(
+				join(outDir, "server", "worker.js"),
+				"utf8",
+			);
+
+			mf = new Miniflare({
+				modules: true,
+				script,
+				compatibilityDate: "2024-09-23",
+				compatibilityFlags: ["nodejs_compat"],
+				assets: {
+					directory: join(outDir, "public"),
+					binding: "ASSETS",
+					routerConfig: {
+						has_user_worker: true,
+						invoke_user_worker_ahead_of_assets: true,
+					},
+					// A directory over ASSETS serves literal paths, no HTML
+					// canonicalization (newer workerd 500s on explicit .html
+					// paths under the default html_handling).
+					assetConfig: {html_handling: "none"},
+				},
+			});
+
+			await mf.ready;
+
+			// Direct children of the base path: a file and a subdirectory.
+			const listResponse = await mf.dispatchFetch("http://localhost/list");
+			expect(listResponse.status).toBe(200);
+			const {listing, staged} = await listResponse.json();
+			expect(staged).toBe(3);
+			expect(listing).toEqual({"about.md": "file", posts: "directory"});
+
+			// Navigating into the subdirectory keeps it enumerable, and the
+			// handles read real content through the binding.
+			const readResponse = await mf.dispatchFetch(
+				"http://localhost/read-posts",
+			);
+			expect(readResponse.status).toBe(200);
+			const {names, text} = await readResponse.json();
+			expect(names).toEqual(["first.md", "second.md"]);
+			expect(text).toBe("# First post");
+		} finally {
+			if (mf) {
+				await mf.dispose();
+			}
+			await FS.rm(tempDir, {recursive: true, force: true}).catch(() => {});
+		}
+	},
+	MINIFLARE_TIMEOUT,
+);


### PR DESCRIPTION
Supersedes #101 (closed). That PR invented a config field to bake files into the worker bundle; this one adds no config at all.

## What this is

Directories opened over Cloudflare's ASSETS binding are now **enumerable**. `entries()`, `keys()`, `values()`, and `for await` work on `CloudflareAssetsDirectory` the same way they do on every other platform's directories. Before this, reads by name worked but any iteration threw `NotSupportedError` — so the one platform without a filesystem was also the one platform where you couldn't list a directory.

The ASSETS binding has no list API, but the build already knows every asset it emitted: the manifest is bundled into the worker as `shovel:assets` (and `@b9g/assets`' middleware already imports it). Enumeration reads that manifest and reports the direct children of the directory's base path — files as file handles, deeper paths as subdirectory handles (deduped), and subdirectories obtained via `getDirectoryHandle()` stay enumerable. The manifest is loaded lazily and memoized, and is injectable through the constructor for tests.

This config is already legal today and now behaves correctly:

```json
{"directories": {"content": {
  "module": "@b9g/platform-cloudflare/directories",
  "export": "CloudflareAssetsDirectory",
  "path": "/content"
}}}
```

## Why it matters — the idiom this unblocks

Nearly every shovel-built site walks a content directory with the same loop:

```ts
for await (const [name, handle] of dir.entries()) {
  if (handle.kind === "directory") { /* recurse */ }
  else if (name.endsWith(".md")) { /* parse frontmatter, collect */ }
}
```

That walk feeds blog indexes, Atom feeds, sitemap generation, prerender route lists, and example-browser UIs. On Node and Bun it runs against `NodeFSDirectory`; on Cloudflare it was impossible, which pushed real deployments into workarounds:

- **Bake steps.** One Worker-deployed site bakes `content/*.md` into a generated TS module at build time, with a comment explaining why: *"on a live Cloudflare Worker there is no filesystem, and the read-only ASSETS directory can't list entries."* The blog index and feed are built from that baked JSON instead of the directory.
- **Hand-maintained route arrays.** A Pages-deployed site prerenders from `const routes = ["/"]` — a list that must be edited by hand every time a post lands, because the route list can't be derived from `content/`.
- **Generated import manifests.** Hundreds of lines of `import a0 from "./audio/xxx.mp3" with {assetBase: ...}` generated by a script that `readdirSync`s the directory — a hardcoded manifest standing in for "list the deployed assets."

All of those collapse into the ordinary `entries()` walk once the deployed directory can enumerate itself.

## Semantics and limits

- **The listing is a build-time snapshot** — which is exactly the lifetime of the ASSETS binding itself. Assets are immutable per deploy; there is no write path and no runtime list API, so the manifest never disagrees with the store. Reads are unchanged.
- **Assets are public and read-only.** Everything in the directory is served at an edge URL and `createWritable()` rejects. That's the existing contract of `dist/public`, not something this PR introduces — a directory of drafts or private files doesn't belong here.
- **Outside a shovel build there is no manifest.** The directory still reads fine by name; enumeration throws `NotSupportedError` with a message that says why. Nothing regresses for bare-wrangler users.
- Getting an arbitrary source directory *into* `dist/public` is still on the user (glob asset imports do it today). Making `content/` first-class is a follow-up.

## Tests

`packages/platform-cloudflare/test/filesystem-assets.test.ts`, against a real Miniflare ASSETS binding:

- `keys()` lists direct children of the base path
- a deeper asset surfaces as a **subdirectory**, not a file
- `values()` yields handles that read real content through the binding
- navigating into a subdirectory keeps it enumerable
- without a manifest, `entries()` still throws `NotSupportedError` (the pre-existing throw test now pins the no-manifest case)

**End to end** (`test/cloudflare-build.test.js`): a real `buildForProduction` run — glob-imported `content/`, a `shovel.json` directory over `CloudflareAssetsDirectory` — executed in Miniflare against a live ASSETS binding, with **no injected manifest**. Enumeration resolves the `shovel:assets` module bundled into the worker, lists file/directory kinds at the base path, navigates into a subdirectory, and reads file content through the binding.

**27/27 cloudflare tests pass · typecheck exit 0 · lint clean.**

## Changelog

### Features

- **Directory enumeration on Cloudflare ASSETS** — Directories backed by the ASSETS binding (`CloudflareAssetsDirectory`) now support `entries()`/`keys()`/`values()`, powered by the asset manifest the build already bundles into the worker. The standard content-walking idiom — blog indexes, feeds, sitemaps, prerender route lists derived from `content/**` — now runs unchanged on Cloudflare Workers and Pages, with no new config. Enumeration reflects the build's asset snapshot (the same lifetime as the binding itself); outside a shovel build, listing still throws `NotSupportedError` while named reads work as before. ([PR #104](https://github.com/bikeshaving/shovel/pull/104))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmBa71chuLM78aDA4LKvf4
