### PR TITLE
feat(cloudflare): wrangler config sync with --save semantics

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -151,6 +151,10 @@ program
 	.description("Build app for production")
 	.option("--platform <name>", "Runtime platform (node, cloudflare, bun)")
 	.option(
+		"--save",
+		"Write missing wrangler config settings the build needs (Cloudflare); never changes values you set",
+	)
+	.option(
 		"--lifecycle [stage]",
 		"Run ServiceWorker lifecycle after build (install or activate, default: activate)",
 	)

--- a/packages/platform-cloudflare/src/platform.ts
+++ b/packages/platform-cloudflare/src/platform.ts
@@ -138,6 +138,11 @@ export async function createDevServer(
 			directory: publicDir,
 			binding: "ASSETS",
 			routerConfig: {has_user_worker: true},
+			// Directories over ASSETS need literal paths: the default
+			// html_handling canonicalizes .html URLs (newer workerd 500s on
+			// the explicit path), breaking getFileHandle("*.html"). This is
+			// also what --save writes to wrangler config, so dev matches prod.
+			assetConfig: {html_handling: "none" as const},
 		},
 	});
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -9,6 +9,11 @@ import {readFile, writeFile} from "fs/promises";
 import type * as ESBuild from "esbuild";
 
 import {ServerBundler} from "../utils/bundler.js";
+import {
+	computeDesired,
+	syncWranglerConfig,
+	usesAssetsDirectory,
+} from "../utils/wrangler.js";
 import {findProjectRoot, findWorkspaceRoot} from "../utils/project.js";
 import {loadPlatformModule} from "../utils/platform.js";
 import type {ProcessedShovelConfig} from "../utils/config.js";
@@ -280,7 +285,7 @@ async function generateExecutablePackageJSON(platform: string) {
  */
 export async function buildCommand(
 	entrypoint: string,
-	options: {platform?: string; lifecycle?: boolean | string},
+	options: {platform?: string; lifecycle?: boolean | string; save?: boolean},
 	config: ProcessedShovelConfig,
 ) {
 	// Use same platform resolution as develop command
@@ -306,6 +311,55 @@ export async function buildCommand(
 		userBuildConfig: config.build,
 		lifecycle: lifecycleOption,
 	});
+
+	// Cloudflare deploys read wrangler config; keep it in step with the build
+	// output. Missing keys are reported (or written with --save); values the
+	// user set are never changed.
+	if (platform === "cloudflare") {
+		const projectRoot = findProjectRoot(dirname(resolve(entrypoint)));
+		const desired = computeDesired({
+			projectRoot,
+			outDir: resolve("dist"),
+			assetsDirectory: usesAssetsDirectory(
+				platformModule.getDefaults().directories ?? {},
+				config.directories ?? {},
+			),
+		});
+		const result = syncWranglerConfig({
+			projectRoot,
+			desired,
+			save: Boolean(options.save),
+		});
+
+		const additions = result.actions.filter((a) => a.kind === "add");
+		const notices = result.actions.filter((a) => a.kind === "notice");
+		const configName = basename(result.path);
+
+		if (result.wrote) {
+			logger.info(
+				result.created
+					? "Created {config}"
+					: "Updated {config} with {count} setting(s)",
+				{config: configName, count: additions.length},
+			);
+			for (const action of additions) {
+				logger.info("  + {change}", {change: action.description});
+			}
+		} else if (additions.length > 0) {
+			logger.warn(
+				result.created
+					? "No wrangler config found. Run with --save to create {config}:"
+					: "{config} is missing settings this build needs (--save to apply):",
+				{config: configName},
+			);
+			for (const action of additions) {
+				logger.warn("  + {change}", {change: action.description});
+			}
+		}
+		for (const action of notices) {
+			logger.warn("wrangler config: {notice}", {notice: action.description});
+		}
+	}
 
 	// Run lifecycle if requested
 	// --lifecycle [stage] runs the ServiceWorker lifecycle

--- a/src/utils/wrangler.ts
+++ b/src/utils/wrangler.ts
@@ -1,0 +1,534 @@
+/**
+ * Wrangler config sync for Cloudflare builds.
+ *
+ * "--save semantics": shovel knows a handful of wrangler settings the build
+ * output requires (entry point, assets binding, html_handling for directory
+ * reads). Like npm editing only "dependencies", we fill in missing keys and
+ * never rewrite ones the user set — an existing value, even one we disagree
+ * with, is an explicit choice and gets a notice instead of an edit.
+ */
+
+import * as FS from "fs";
+import {join, relative} from "path";
+import {getLogger} from "@logtape/logtape";
+
+const logger = getLogger(["shovel", "build"]);
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+/** The wrangler settings a shovel build requires. */
+export interface WranglerDesired {
+	main: string;
+	compatibilityDate: string;
+	/** Flags the worker needs present in compatibility_flags */
+	compatibilityFlags: string[];
+	assets: {
+		directory: string;
+		binding: string;
+		/** Set when a directory is served over the ASSETS binding */
+		htmlHandling: "none" | null;
+	};
+}
+
+export interface WranglerAction {
+	kind: "add" | "notice";
+	/** Human-readable, e.g. `[assets] html_handling = "none"` */
+	description: string;
+}
+
+export interface WranglerSyncResult {
+	/** Config file path, or the path that would be created */
+	path: string;
+	/** True when no config existed and a scaffold is involved */
+	created: boolean;
+	/** True when `save` was set and the file was written */
+	wrote: boolean;
+	actions: WranglerAction[];
+	/** The full contents that were (or would be) written; null if no changes */
+	contents: string | null;
+}
+
+interface DirectoryModuleConfig {
+	module?: string;
+	export?: string;
+}
+
+// ============================================================================
+// DESIRED SETTINGS
+// ============================================================================
+
+/**
+ * Whether the effective directories config serves a directory over the
+ * ASSETS binding. Platform defaults map "public" to CloudflareAssetsDirectory,
+ * so this is true unless the user overrides every such directory away.
+ * A directory over ASSETS needs literal paths: the default html_handling
+ * canonicalizes .html URLs (and newer workerd 500s on the explicit path),
+ * which breaks getFileHandle for any .html file.
+ */
+export function usesAssetsDirectory(
+	platformDirectories: Record<string, DirectoryModuleConfig>,
+	userDirectories: Record<string, DirectoryModuleConfig>,
+): boolean {
+	const names = new Set([
+		...Object.keys(platformDirectories),
+		...Object.keys(userDirectories),
+	]);
+	for (const name of names) {
+		const platformConfig = platformDirectories[name] || {};
+		const userConfig = userDirectories[name] || {};
+		const merged = {...platformConfig, ...userConfig};
+		// A user module without an export means the module's default export,
+		// not the platform default's named export (same rule as config codegen).
+		if (userConfig.module && !userConfig.export) {
+			delete merged.export;
+		}
+
+		if (
+			merged.module === "@b9g/platform-cloudflare/directories" &&
+			merged.export === "CloudflareAssetsDirectory"
+		) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+export function computeDesired({
+	projectRoot,
+	outDir,
+	assetsDirectory,
+}: {
+	projectRoot: string;
+	outDir: string;
+	assetsDirectory: boolean;
+}): WranglerDesired {
+	const rel = (p: string) => relative(projectRoot, p).split("\\").join("/");
+	return {
+		main: rel(join(outDir, "server", "worker.js")),
+		compatibilityDate: "2024-09-23",
+		compatibilityFlags: ["nodejs_compat"],
+		assets: {
+			directory: rel(join(outDir, "public")) + "/",
+			binding: "ASSETS",
+			htmlHandling: assetsDirectory ? "none" : null,
+		},
+	};
+}
+
+// ============================================================================
+// TOML (append-only editing)
+// ============================================================================
+
+interface TomlLayout {
+	/** Keys defined at the top level (before any [table]) */
+	topLevelKeys: Set<string>;
+	/** Line index of the first table header, or lines.length */
+	firstTableLine: number;
+	/** Keys inside [assets], or null if the table doesn't exist */
+	assetsKeys: Set<string> | null;
+	/** Line index just past the last line of [assets] */
+	assetsEnd: number;
+	/** True for `assets = {...}` inline tables or [[assets]] arrays we won't touch */
+	assetsUnsupported: boolean;
+}
+
+function scanToml(lines: string[]): TomlLayout {
+	const layout: TomlLayout = {
+		topLevelKeys: new Set(),
+		firstTableLine: lines.length,
+		assetsKeys: null,
+		assetsEnd: lines.length,
+		assetsUnsupported: false,
+	};
+
+	let section: string | null = "";
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		const header = /^\s*\[\[?\s*([A-Za-z0-9_."'-]+)\s*\]?\]/.exec(line);
+		if (header) {
+			if (layout.firstTableLine === lines.length) {
+				layout.firstTableLine = i;
+			}
+			if (section === "assets") {
+				layout.assetsEnd = i;
+			}
+			section = header[1];
+			if (section === "assets") {
+				if (line.trimStart().startsWith("[[")) {
+					layout.assetsUnsupported = true;
+				}
+				layout.assetsKeys ??= new Set();
+				layout.assetsEnd = lines.length;
+			}
+			continue;
+		}
+
+		const kv = /^\s*([A-Za-z0-9_-]+)\s*=/.exec(line);
+		if (kv) {
+			if (section === "") {
+				layout.topLevelKeys.add(kv[1]);
+				if (kv[1] === "assets") {
+					layout.assetsUnsupported = true;
+				}
+			} else if (section === "assets") {
+				layout.assetsKeys?.add(kv[1]);
+			}
+		}
+	}
+
+	return layout;
+}
+
+function patchToml(
+	raw: string,
+	desired: WranglerDesired,
+): {contents: string | null; actions: WranglerAction[]} {
+	const actions: WranglerAction[] = [];
+	const lines = raw.split("\n");
+	const layout = scanToml(lines);
+
+	if (layout.assetsUnsupported) {
+		actions.push({
+			kind: "notice",
+			description:
+				"assets is configured in a form shovel doesn't edit " +
+				"(inline table or [[assets]]) — apply the settings manually",
+		});
+		return {contents: null, actions};
+	}
+
+	// Top-level keys must appear before the first table header.
+	const topAdditions: string[] = [];
+	if (!layout.topLevelKeys.has("main")) {
+		topAdditions.push(`main = "${desired.main}"`);
+		actions.push({kind: "add", description: `main = "${desired.main}"`});
+	}
+	if (!layout.topLevelKeys.has("compatibility_date")) {
+		topAdditions.push(`compatibility_date = "${desired.compatibilityDate}"`);
+		actions.push({
+			kind: "add",
+			description: `compatibility_date = "${desired.compatibilityDate}"`,
+		});
+	}
+	if (!layout.topLevelKeys.has("compatibility_flags")) {
+		const flags = desired.compatibilityFlags
+			.map((f) => JSON.stringify(f))
+			.join(", ");
+		topAdditions.push(`compatibility_flags = [${flags}]`);
+		actions.push({
+			kind: "add",
+			description: `compatibility_flags = [${flags}]`,
+		});
+	} else {
+		for (const flag of desired.compatibilityFlags) {
+			// Arrays may span lines; a whole-file check is the honest test we
+			// can do without a TOML parser, and a false positive only skips a
+			// notice.
+			if (!raw.includes(flag)) {
+				actions.push({
+					kind: "notice",
+					description: `compatibility_flags should include "${flag}"`,
+				});
+			}
+		}
+	}
+
+	const assetsAdditions: string[] = [];
+	const wantAssets: Array<[string, string]> = [
+		["directory", `"${desired.assets.directory}"`],
+		["binding", `"${desired.assets.binding}"`],
+	];
+	if (desired.assets.htmlHandling) {
+		wantAssets.push(["html_handling", `"${desired.assets.htmlHandling}"`]);
+	}
+	for (const [key, value] of wantAssets) {
+		if (!layout.assetsKeys?.has(key)) {
+			assetsAdditions.push(`${key} = ${value}`);
+			actions.push({kind: "add", description: `[assets] ${key} = ${value}`});
+		}
+	}
+	if (
+		desired.assets.htmlHandling &&
+		layout.assetsKeys?.has("html_handling") &&
+		!/html_handling\s*=\s*"none"/.test(raw)
+	) {
+		actions.push({
+			kind: "notice",
+			description:
+				'html_handling is set to something other than "none"; directory ' +
+				"reads of .html files over ASSETS are unreliable without it",
+		});
+	}
+
+	if (topAdditions.length === 0 && assetsAdditions.length === 0) {
+		return {contents: null, actions};
+	}
+
+	const out = [...lines];
+	// Splice deepest-first so earlier indices stay valid.
+	if (assetsAdditions.length > 0) {
+		if (layout.assetsKeys === null) {
+			const block = ["", "[assets]", ...assetsAdditions];
+			// Append at end of file.
+			while (out.length > 0 && out[out.length - 1].trim() === "") {
+				out.pop();
+			}
+			out.push(...block, "");
+		} else {
+			let insertAt = layout.assetsEnd;
+			while (insertAt > 0 && out[insertAt - 1].trim() === "") {
+				insertAt--;
+			}
+			out.splice(insertAt, 0, ...assetsAdditions);
+		}
+	}
+	if (topAdditions.length > 0) {
+		out.splice(layout.firstTableLine, 0, ...topAdditions);
+	}
+
+	return {contents: out.join("\n"), actions};
+}
+
+export function scaffoldToml(desired: WranglerDesired, name: string): string {
+	const flags = desired.compatibilityFlags
+		.map((f) => JSON.stringify(f))
+		.join(", ");
+	const lines = [
+		`name = "${name}"`,
+		`main = "${desired.main}"`,
+		`compatibility_date = "${desired.compatibilityDate}"`,
+		`compatibility_flags = [${flags}]`,
+		"",
+		"[assets]",
+		`directory = "${desired.assets.directory}"`,
+		`binding = "${desired.assets.binding}"`,
+	];
+	if (desired.assets.htmlHandling) {
+		lines.push(`html_handling = "${desired.assets.htmlHandling}"`);
+	}
+	lines.push("");
+	return lines.join("\n");
+}
+
+// ============================================================================
+// JSON / JSONC
+// ============================================================================
+
+function hasJsoncSyntax(raw: string): boolean {
+	// Strings could contain these sequences, but a false positive only
+	// downgrades an edit to a printed suggestion.
+	return raw.includes("//") || raw.includes("/*") || /,\s*[}\]]/.test(raw);
+}
+
+function patchJson(
+	raw: string,
+	desired: WranglerDesired,
+): {contents: string | null; actions: WranglerAction[]} {
+	const actions: WranglerAction[] = [];
+
+	let parsed: Record<string, unknown>;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (error) {
+		logger.debug("wrangler config parse failed", {error});
+		actions.push({
+			kind: "notice",
+			description: "config file could not be parsed — fix it manually",
+		});
+		return {contents: null, actions};
+	}
+
+	let changed = false;
+	if (parsed.main === undefined) {
+		parsed.main = desired.main;
+		actions.push({kind: "add", description: `main: "${desired.main}"`});
+		changed = true;
+	}
+	if (parsed.compatibility_date === undefined) {
+		parsed.compatibility_date = desired.compatibilityDate;
+		actions.push({
+			kind: "add",
+			description: `compatibility_date: "${desired.compatibilityDate}"`,
+		});
+		changed = true;
+	}
+	if (parsed.compatibility_flags === undefined) {
+		parsed.compatibility_flags = [...desired.compatibilityFlags];
+		actions.push({
+			kind: "add",
+			description: `compatibility_flags: ${JSON.stringify(desired.compatibilityFlags)}`,
+		});
+		changed = true;
+	} else if (Array.isArray(parsed.compatibility_flags)) {
+		for (const flag of desired.compatibilityFlags) {
+			if (!parsed.compatibility_flags.includes(flag)) {
+				actions.push({
+					kind: "notice",
+					description: `compatibility_flags should include "${flag}"`,
+				});
+			}
+		}
+	}
+
+	const assets =
+		typeof parsed.assets === "object" && parsed.assets !== null
+			? (parsed.assets as Record<string, unknown>)
+			: undefined;
+	if (assets === undefined) {
+		const block: Record<string, unknown> = {
+			directory: desired.assets.directory,
+			binding: desired.assets.binding,
+		};
+		if (desired.assets.htmlHandling) {
+			block.html_handling = desired.assets.htmlHandling;
+		}
+		parsed.assets = block;
+		actions.push({
+			kind: "add",
+			description: `assets: ${JSON.stringify(block)}`,
+		});
+		changed = true;
+	} else {
+		const want: Array<[string, string]> = [
+			["directory", desired.assets.directory],
+			["binding", desired.assets.binding],
+		];
+		if (desired.assets.htmlHandling) {
+			want.push(["html_handling", desired.assets.htmlHandling]);
+		}
+		for (const [key, value] of want) {
+			if (assets[key] === undefined) {
+				assets[key] = value;
+				actions.push({
+					kind: "add",
+					description: `assets.${key}: "${value}"`,
+				});
+				changed = true;
+			}
+		}
+		if (
+			desired.assets.htmlHandling &&
+			assets.html_handling !== undefined &&
+			assets.html_handling !== "none"
+		) {
+			actions.push({
+				kind: "notice",
+				description:
+					'assets.html_handling is set to something other than "none"; ' +
+					"directory reads of .html files over ASSETS are unreliable " +
+					"without it",
+			});
+		}
+	}
+
+	if (!changed) {
+		return {contents: null, actions};
+	}
+
+	const indent = /\n\t/.test(raw) ? "\t" : "  ";
+	return {contents: JSON.stringify(parsed, null, indent) + "\n", actions};
+}
+
+// ============================================================================
+// SYNC
+// ============================================================================
+
+function workerName(projectRoot: string): string {
+	let name = "shovel-app";
+	try {
+		const pkg = JSON.parse(
+			FS.readFileSync(join(projectRoot, "package.json"), "utf8"),
+		);
+		if (typeof pkg.name === "string" && pkg.name.length > 0) {
+			name = pkg.name;
+		}
+	} catch (error) {
+		// package.json is optional here; the fallback name is fine.
+		logger.debug("no package.json name for worker name", {error});
+	}
+	// Worker names: lowercase alphanumerics and dashes.
+	const sanitized = name
+		.toLowerCase()
+		.replace(/^@/, "")
+		.replace(/[^a-z0-9-]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return sanitized || "shovel-app";
+}
+
+/**
+ * Compare the project's wrangler config with what the build requires.
+ * Returns the additions (and notices for user-set values we won't touch);
+ * with `save`, missing keys are written — existing values are never changed.
+ *
+ * Precedence mirrors wrangler: wrangler.jsonc, then wrangler.json, then
+ * wrangler.toml.
+ */
+export function syncWranglerConfig({
+	projectRoot,
+	desired,
+	save,
+}: {
+	projectRoot: string;
+	desired: WranglerDesired;
+	save: boolean;
+}): WranglerSyncResult {
+	const candidates = ["wrangler.jsonc", "wrangler.json", "wrangler.toml"];
+	let path: string | null = null;
+	for (const candidate of candidates) {
+		if (FS.existsSync(join(projectRoot, candidate))) {
+			path = join(projectRoot, candidate);
+			break;
+		}
+	}
+
+	if (path === null) {
+		const scaffoldPath = join(projectRoot, "wrangler.toml");
+		const contents = scaffoldToml(desired, workerName(projectRoot));
+		if (save) {
+			FS.writeFileSync(scaffoldPath, contents);
+		}
+		return {
+			path: scaffoldPath,
+			created: true,
+			wrote: save,
+			actions: [{kind: "add", description: "create wrangler.toml"}],
+			contents,
+		};
+	}
+
+	const raw = FS.readFileSync(path, "utf8");
+	let result: {contents: string | null; actions: WranglerAction[]};
+	if (path.endsWith(".toml")) {
+		result = patchToml(raw, desired);
+	} else if (path.endsWith(".jsonc") && hasJsoncSyntax(raw)) {
+		// Editing would drop comments; report what's missing instead.
+		const probe = patchJson(raw.replace(/\/\/[^\n]*/g, ""), desired);
+		result = {contents: null, actions: probe.actions};
+		if (probe.contents !== null) {
+			result.actions.push({
+				kind: "notice",
+				description:
+					"wrangler.jsonc has comments, which shovel won't rewrite — " +
+					"apply the additions above manually",
+			});
+		}
+	} else {
+		result = patchJson(raw, desired);
+	}
+
+	const wrote = save && result.contents !== null;
+	if (wrote && result.contents !== null) {
+		FS.writeFileSync(path, result.contents);
+	}
+
+	return {
+		path,
+		created: false,
+		wrote,
+		actions: result.actions,
+		contents: result.contents,
+	};
+}

--- a/test/wrangler-save.test.ts
+++ b/test/wrangler-save.test.ts
@@ -1,0 +1,357 @@
+import * as FS from "fs/promises";
+import * as OS from "os";
+import {join} from "path";
+import {test, expect, describe} from "bun:test";
+import {
+	computeDesired,
+	scaffoldToml,
+	syncWranglerConfig,
+	usesAssetsDirectory,
+} from "../src/utils/wrangler.js";
+
+const CF_DIRECTORIES_MODULE = "@b9g/platform-cloudflare/directories";
+const PLATFORM_DEFAULTS = {
+	public: {module: CF_DIRECTORIES_MODULE, export: "CloudflareAssetsDirectory"},
+};
+
+function desired(assetsDirectory = true) {
+	return computeDesired({
+		projectRoot: "/proj",
+		outDir: "/proj/dist",
+		assetsDirectory,
+	});
+}
+
+async function tempProject(files: Record<string, string>) {
+	const dir = join(
+		OS.tmpdir(),
+		`shovel-wrangler-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	await FS.mkdir(dir, {recursive: true});
+	for (const [name, contents] of Object.entries(files)) {
+		await FS.writeFile(join(dir, name), contents);
+	}
+	return {
+		dir,
+		read: (name: string) => FS.readFile(join(dir, name), "utf8"),
+		cleanup: () => FS.rm(dir, {recursive: true, force: true}),
+	};
+}
+
+describe("usesAssetsDirectory", () => {
+	test("true under platform defaults alone", () => {
+		expect(usesAssetsDirectory(PLATFORM_DEFAULTS, {})).toBe(true);
+	});
+
+	test("false when the user overrides public with another module", () => {
+		// A user module without an export means that module's default export,
+		// not the platform default's named export.
+		expect(
+			usesAssetsDirectory(PLATFORM_DEFAULTS, {
+				public: {module: "@b9g/filesystem/node-fs"},
+			}),
+		).toBe(false);
+	});
+
+	test("true when any user directory targets CloudflareAssetsDirectory", () => {
+		expect(
+			usesAssetsDirectory(
+				{},
+				{
+					content: {
+						module: CF_DIRECTORIES_MODULE,
+						export: "CloudflareAssetsDirectory",
+					},
+				},
+			),
+		).toBe(true);
+	});
+});
+
+describe("computeDesired", () => {
+	test("paths are project-relative with forward slashes", () => {
+		const d = desired();
+		expect(d.main).toBe("dist/server/worker.js");
+		expect(d.assets.directory).toBe("dist/public/");
+		expect(d.assets.htmlHandling).toBe("none");
+	});
+
+	test("html_handling not required without an assets directory", () => {
+		expect(desired(false).assets.htmlHandling).toBe(null);
+	});
+});
+
+describe("syncWranglerConfig: no config file", () => {
+	test("reports a scaffold without writing when save is off", async () => {
+		const project = await tempProject({
+			"package.json": JSON.stringify({name: "@me/My App!"}),
+		});
+		try {
+			const result = syncWranglerConfig({
+				projectRoot: project.dir,
+				desired: desired(),
+				save: false,
+			});
+			expect(result.created).toBe(true);
+			expect(result.wrote).toBe(false);
+			expect(result.contents).toContain('name = "me-my-app"');
+			expect(
+				await FS.access(join(project.dir, "wrangler.toml")).then(
+					() => true,
+					() => false,
+				),
+			).toBe(false);
+		} finally {
+			await project.cleanup();
+		}
+	});
+
+	test("writes a complete scaffold with save", async () => {
+		const project = await tempProject({
+			"package.json": JSON.stringify({name: "blog"}),
+		});
+		try {
+			const result = syncWranglerConfig({
+				projectRoot: project.dir,
+				desired: desired(),
+				save: true,
+			});
+			expect(result.wrote).toBe(true);
+			const written = await project.read("wrangler.toml");
+			expect(written).toBe(scaffoldToml(desired(), "blog"));
+			expect(written).toContain('main = "dist/server/worker.js"');
+			expect(written).toContain('compatibility_flags = ["nodejs_compat"]');
+			expect(written).toContain("[assets]");
+			expect(written).toContain('html_handling = "none"');
+		} finally {
+			await project.cleanup();
+		}
+	});
+});
+
+describe("syncWranglerConfig: wrangler.toml", () => {
+	test("fills missing keys and leaves existing lines untouched", async () => {
+		const original = [
+			`name = "my-worker"`,
+			`main = "dist/server/worker.js"`,
+			``,
+			`[vars]`,
+			`FOO = "bar"`,
+			``,
+			`[assets]`,
+			`directory = "dist/public/"`,
+			``,
+		].join("\n");
+		const project = await tempProject({"wrangler.toml": original});
+		try {
+			const result = syncWranglerConfig({
+				projectRoot: project.dir,
+				desired: desired(),
+				save: true,
+			});
+			expect(result.wrote).toBe(true);
+			const written = await project.read("wrangler.toml");
+
+			// Every original line survives verbatim.
+			for (const line of original.split("\n")) {
+				expect(written).toContain(line);
+			}
+			// Top-level additions land before the first table.
+			const compatIndex = written.indexOf("compatibility_date");
+			expect(compatIndex).toBeGreaterThan(-1);
+			expect(compatIndex).toBeLessThan(written.indexOf("[vars]"));
+			// [assets] additions land inside [assets], and [vars] stays clean.
+			const varsSection = written.slice(
+				written.indexOf("[vars]"),
+				written.indexOf("[assets]"),
+			);
+			expect(varsSection).not.toContain("binding");
+			const assetsSection = written.slice(written.indexOf("[assets]"));
+			expect(assetsSection).toContain(`binding = "ASSETS"`);
+			expect(assetsSection).toContain(`html_handling = "none"`);
+			// main already existed; it is not duplicated.
+			expect(written.split("main =").length).toBe(2);
+		} finally {
+			await project.cleanup();
+		}
+	});
+
+	test("appends an [assets] table when absent", async () => {
+		const project = await tempProject({
+			"wrangler.toml": `name = "w"\nmain = "dist/server/worker.js"\ncompatibility_date = "2025-01-01"\ncompatibility_flags = ["nodejs_compat"]\n`,
+		});
+		try {
+			const result = syncWranglerConfig({
+				projectRoot: project.dir,
+				desired: desired(),
+				save: true,
+			});
+			expect(result.wrote).toBe(true);
+			const written = await project.read("wrangler.toml");
+			expect(written).toContain(
+				`[assets]\ndirectory = "dist/public/"\nbinding = "ASSETS"\nhtml_handling = "none"`,
+			);
+			// The user's compatibility_date is not touched.
+			expect(written).toContain(`compatibility_date = "2025-01-01"`);
+		} finally {
+			await project.cleanup();
+		}
+	});
+
+	test("never overrides a user-set html_handling; notices instead", async () => {
+		const original = `name = "w"\nmain = "dist/server/worker.js"\ncompatibility_date = "2025-01-01"\ncompatibility_flags = ["nodejs_compat"]\n\n[assets]\ndirectory = "dist/public/"\nbinding = "ASSETS"\nhtml_handling = "auto-trailing-slash"\n`;
+		const project = await tempProject({"wrangler.toml": original});
+		try {
+			const result = syncWranglerConfig({
+				projectRoot: project.dir,
+				desired: desired(),
+				save: true,
+			});
+			expect(result.wrote).toBe(false);
+			expect(await project.read("wrangler.toml")).toBe(original);
+			expect(
+				result.actions.some(
+					(a) => a.kind === "notice" && a.description.includes("html_handling"),
+				),
+			).toBe(true);
+		} finally {
+			await project.cleanup();
+		}
+	});
+
+	test("notices when compatibility_flags lacks nodejs_compat", async () => {
+		const project = await tempProject({
+			"wrangler.toml": `name = "w"\nmain = "dist/server/worker.js"\ncompatibility_date = "2025-01-01"\ncompatibility_flags = []\n\n[assets]\ndirectory = "dist/public/"\nbinding = "ASSETS"\nhtml_handling = "none"\n`,
+		});
+		try {
+			const result = syncWranglerConfig({
+				projectRoot: project.dir,
+				desired: desired(),
+				save: true,
+			});
+			expect(
+				result.actions.some(
+					(a) => a.kind === "notice" && a.description.includes("nodejs_compat"),
+				),
+			).toBe(true);
+		} finally {
+			await project.cleanup();
+		}
+	});
+
+	test("bails to a notice on inline assets tables", async () => {
+		const original = `name = "w"\nassets = {directory = "dist/public/"}\n`;
+		const project = await tempProject({"wrangler.toml": original});
+		try {
+			const result = syncWranglerConfig({
+				projectRoot: project.dir,
+				desired: desired(),
+				save: true,
+			});
+			expect(result.wrote).toBe(false);
+			expect(await project.read("wrangler.toml")).toBe(original);
+			expect(result.actions.some((a) => a.kind === "notice")).toBe(true);
+		} finally {
+			await project.cleanup();
+		}
+	});
+});
+
+describe("syncWranglerConfig: wrangler.json / wrangler.jsonc", () => {
+	test("fills missing keys in wrangler.json", async () => {
+		const project = await tempProject({
+			"wrangler.json": JSON.stringify(
+				{name: "w", vars: {FOO: "bar"}},
+				null,
+				"\t",
+			),
+		});
+		try {
+			const result = syncWranglerConfig({
+				projectRoot: project.dir,
+				desired: desired(),
+				save: true,
+			});
+			expect(result.wrote).toBe(true);
+			const written = JSON.parse(await project.read("wrangler.json"));
+			expect(written.name).toBe("w");
+			expect(written.vars).toEqual({FOO: "bar"});
+			expect(written.main).toBe("dist/server/worker.js");
+			expect(written.assets).toEqual({
+				directory: "dist/public/",
+				binding: "ASSETS",
+				html_handling: "none",
+			});
+			// Indentation style is preserved.
+			expect(await project.read("wrangler.json")).toContain("\n\t");
+		} finally {
+			await project.cleanup();
+		}
+	});
+
+	test("does not rewrite a commented wrangler.jsonc; suggests instead", async () => {
+		const original = `{\n\t// my worker\n\t"name": "w"\n}\n`;
+		const project = await tempProject({"wrangler.jsonc": original});
+		try {
+			const result = syncWranglerConfig({
+				projectRoot: project.dir,
+				desired: desired(),
+				save: true,
+			});
+			expect(result.wrote).toBe(false);
+			expect(await project.read("wrangler.jsonc")).toBe(original);
+			expect(result.actions.some((a) => a.kind === "add")).toBe(true);
+			expect(
+				result.actions.some(
+					(a) => a.kind === "notice" && a.description.includes("comments"),
+				),
+			).toBe(true);
+		} finally {
+			await project.cleanup();
+		}
+	});
+
+	test("jsonc takes precedence over toml, matching wrangler", async () => {
+		const project = await tempProject({
+			"wrangler.jsonc": `{"name": "w"}`,
+			"wrangler.toml": `name = "other"\n`,
+		});
+		try {
+			const result = syncWranglerConfig({
+				projectRoot: project.dir,
+				desired: desired(),
+				save: false,
+			});
+			expect(result.path.endsWith("wrangler.jsonc")).toBe(true);
+		} finally {
+			await project.cleanup();
+		}
+	});
+
+	test("a fully configured file yields no actions", async () => {
+		const project = await tempProject({
+			"wrangler.json": JSON.stringify({
+				name: "w",
+				main: "dist/server/worker.js",
+				compatibility_date: "2025-01-01",
+				compatibility_flags: ["nodejs_compat"],
+				assets: {
+					directory: "dist/public/",
+					binding: "ASSETS",
+					html_handling: "none",
+				},
+			}),
+		});
+		try {
+			const result = syncWranglerConfig({
+				projectRoot: project.dir,
+				desired: desired(),
+				save: true,
+			});
+			expect(result.wrote).toBe(false);
+			expect(result.actions).toEqual([]);
+		} finally {
+			await project.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
Follows the discussion on #104's config story: shovel now helps with wrangler config the way `npm install --save` helps with package.json — it owns the keys it understands and touches nothing else.

## What this is

`shovel build --platform cloudflare` now compares the project's wrangler config against what the build output actually requires:

- `main` — the built worker entry (`dist/server/worker.js`)
- `compatibility_date` / `compatibility_flags` (`nodejs_compat`)
- `[assets]` — `directory`, `binding = "ASSETS"`
- `html_handling = "none"` — **only** when a directory is served over the ASSETS binding (true by default: the platform maps `public` to `CloudflareAssetsDirectory`)

After every build, missing keys are reported. With `--save`, they're written. With no wrangler config at all, `--save` scaffolds a complete `wrangler.toml` (name derived from package.json).

## The rule: fill gaps, never override

An existing value — even one we disagree with — is an explicit user choice. It gets a notice, not an edit:

- `html_handling` set to anything but `"none"` while a directory rides ASSETS → notice explaining `.html` reads are unreliable
- `compatibility_flags` present but missing `nodejs_compat` → notice, not an array rewrite

That one rule is what makes auto-editing trustworthy, and it conveniently means TOML editing is **append-only**: top-level keys insert before the first table, `[assets]` keys insert inside their table, and every user line survives byte-for-byte (tested). `wrangler.json` is patched via parse/stringify with indent detection; a `wrangler.jsonc` with comments is never rewritten — the additions are printed for manual application. Precedence mirrors wrangler: `jsonc` > `json` > `toml`. Inline `assets = {...}` tables and `[[assets]]` arrays are declined with a notice rather than guessed at.

## Dev server fix

`createDevServer` already binds `dist/public` as ASSETS in the dev Miniflare — but with default `html_handling`, so `getFileHandle("*.html")` through a directory breaks in dev exactly the way it did in CI (newer workerd 500s the explicit path). Dev now sets `html_handling: "none"`, matching what `--save` writes: dev and production agree.

One deliberate consequence to flag: with `"none"`, the assets layer stops resolving pretty URLs (`/about` → `about.html`, `/` → `index.html`). In shovel's architecture routes belong to the router and assets are files, so this is the coherent contract — but it is a behavior change in dev for anyone who relied on asset-layer canonicalization.

## Tests

`test/wrangler-save.test.ts` (16 tests): scaffold with/without `--save`, append-only TOML placement (top-level before first table, `[assets]` keys in-table, `[vars]` untouched, no duplicate keys), user-set `html_handling` respected with a notice, `nodejs_compat` notice, inline-table bailout, `wrangler.json` patching with indent preservation, commented-`jsonc` refusal, wrangler-matching precedence, and a fully configured file yielding zero actions.

**16/16 new tests · 37 cloudflare-suite tests pass · 24 build tests pass · typecheck exit 0 · lint clean.**

## Changelog

### Features

- **Wrangler config sync (`--save`)** — `shovel build --platform cloudflare` now checks wrangler config against the build output (`main`, compatibility settings, the `[assets]` binding, and `html_handling = "none"` when a directory is served over ASSETS) and reports what's missing; `shovel build --save` writes the missing keys, npm-style: gaps are filled, values you set are never changed. With no config present, `--save` scaffolds a complete `wrangler.toml`. The dev server now also serves ASSETS with `html_handling: "none"`, so directory reads of `.html` files behave the same in dev and production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmBa71chuLM78aDA4LKvf4