### PR TITLE
test(platform): fix worker-errors flake at the root

### DIFF
--- a/packages/platform/test/worker-errors.test.ts
+++ b/packages/platform/test/worker-errors.test.ts
@@ -37,9 +37,20 @@ const TIMEOUT = 20000;
 // assertion (observed timing out at ~5s on CI).
 const REQUEST_TIMEOUT = 15000;
 
+// Test workers must speak the pool's shutdown protocol: gracefulShutdown()
+// waits for "shutdown-complete" and only falls back to a 5s timeout. A worker
+// that never replies makes every terminate() stall for the full 5s, which
+// pushed the afterEach hook over bun's hook timeout on slow CI (the flake
+// #98 papered over with longer test timeouts).
 const GOOD_WORKER_CODE = `
 self.addEventListener("fetch", (event) => {
 	event.respondWith(new Response("Hello"));
+});
+self.addEventListener("message", (event) => {
+	const message = event.data || event;
+	if (message?.type === "shutdown") {
+		postMessage({type: "shutdown-complete"});
+	}
 });
 postMessage({type: "ready"});
 `;
@@ -386,6 +397,12 @@ throw new Error("Initial error");
 				`
 self.addEventListener("fetch", (event) => {
 	event.respondWith(new Response("Fixed!"));
+});
+self.addEventListener("message", (event) => {
+	const message = event.data || event;
+	if (message?.type === "shutdown") {
+		postMessage({type: "shutdown-complete"});
+	}
 });
 postMessage({type: "ready"});
 `,


### PR DESCRIPTION
## The flake

`Worker Error Propagation > successful load works after fixing errors` fails intermittently with "a beforeEach/afterEach hook timed out" — most recently bouncing #104 out of the merge queue on an otherwise-green run (1982/1984 passed).

## Root cause

`ServiceWorkerPool.#gracefulShutdown()` posts `{type: "shutdown"}` and waits for `shutdown-complete`, falling back to a **5s timeout**. Real workers reply through the runtime message loop — but this suite's hand-written test workers (`addEventListener("fetch") + postMessage(ready)`) never reply. So every `gracefulShutdown` in the suite silently burned the full 5s, `pool.terminate()` in `afterEach` took ~5s + temp-dir cleanup, and bun's default **hook timeout is exactly 5s**. The suite lived permanently on the cliff edge; CI load decided which runs fell off. #98 raised the *test* timeouts, which couldn't help — the hooks kept the default.

The tell was in the timings: passing tests at `[5008ms]`, the failing one at `[10014ms]` — multiples of the 5s fallback, not slow CI.

## The fix

Teach the suite's workers the protocol (same as `worker-logging.test.ts` already does): a message listener replying `shutdown-complete`. The broken workers various tests load never finish module evaluation, never enter the pool, and are unaffected.

- Suite time: **~40s of stalls → ~150ms total**
- The 5s cliff is removed, not pushed back
- 20 consecutive local runs: 0 failures; full platform suite (173 tests) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmBa71chuLM78aDA4LKvf4