### PR TITLE
chore(release): v0.2.22 — Cloudflare ASSETS directory enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Shovel will be documented in this file.
 
+## [0.2.22] - 2026-08-11
+
+### Features
+
+- **Directory enumeration on Cloudflare ASSETS** — Directories backed by the ASSETS binding (`CloudflareAssetsDirectory`) now support `entries()`/`keys()`/`values()`, powered by the asset manifest the build already bundles into the worker. The standard content-walking idiom — blog indexes, feeds, sitemaps, prerender route lists derived from `content/**` — now runs unchanged on Cloudflare Workers and Pages, with no new config. Enumeration reflects the build's asset snapshot (the same lifetime as the binding itself); outside a shovel build, listing still throws `NotSupportedError` while named reads work as before. ([PR #104](https://github.com/bikeshaving/shovel/pull/104))
+
+### Dependencies
+
+- `@b9g/platform-cloudflare` 0.1.18
+
 ## [0.2.21] - 2026-07-14
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b9g/shovel",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "description": "ServiceWorker-first universal deployment platform. Write ServiceWorker apps once, deploy anywhere (Node/Bun/Cloudflare). Registry-based multi-app orchestration.",
   "license": "MIT",
   "repository": {

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b9g/platform-cloudflare",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Cloudflare Workers platform adapter for Shovel - already ServiceWorker-based!",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release PR for **v0.2.22**, containing #104 (the only change on main since v0.2.21).

- `@b9g/shovel` 0.2.21 → **0.2.22**
- `@b9g/platform-cloudflare` 0.1.17 → **0.1.18** (where the feature lives; root's `workspace:*` resolves to it at publish)
- CHANGELOG entry lifted from #104's changelog section

After this merges: tag and `npm publish` are manual (`@b9g/platform-cloudflare` first, then `@b9g/shovel`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmBa71chuLM78aDA4LKvf4