### PR TITLE
chore(release): v0.2.23 — ASSETS enumeration hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Shovel will be documented in this file.
 
+## [0.2.23] - 2026-08-11
+
+### Bug Fixes
+
+- **ASSETS directory enumeration hardened** — `@b9g/platform-cloudflare/directories` no longer imports the `shovel:assets` virtual module from library code, which broke consumers bundling outside a shovel build ("Could not resolve shovel:assets" under plain wrangler/esbuild/Vite); the manifest is registered at worker startup via the new `@b9g/assets/manifest` registry. Enumeration is now indexed (no full-manifest rescan per call), malformed manifests degrade to `NotSupportedError` instead of crashing, file/directory name collisions resolve deterministically to the directory, and `getFileHandle` resolves through the manifest without a network probe — halving ASSETS subrequests for list-then-read walks. ([PR #109](https://github.com/bikeshaving/shovel/pull/109))
+
+### Dependencies
+
+- `@b9g/platform-cloudflare` 0.1.19, `@b9g/assets` 0.2.2
+
 ## [0.2.22] - 2026-08-11
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b9g/shovel",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "ServiceWorker-first universal deployment platform. Write ServiceWorker apps once, deploy anywhere (Node/Bun/Cloudflare). Registry-based multi-app orchestration.",
   "license": "MIT",
   "repository": {

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b9g/assets",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "build": "libuild build --save",

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b9g/platform-cloudflare",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Cloudflare Workers platform adapter for Shovel - already ServiceWorker-based!",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release PR for **v0.2.23**, containing #109 (plus the test-only #107, both merged since v0.2.22).

- `@b9g/shovel` 0.2.22 → **0.2.23**
- `@b9g/platform-cloudflare` 0.1.18 → **0.1.19** (the hardening — fixes the 0.1.18 build break for non-shovel bundler consumers)
- `@b9g/assets` 0.2.1 → **0.2.2** (new `./manifest` registry export)
- CHANGELOG entry lifted from #109

Publish order after merge: `@b9g/assets` → `@b9g/platform-cloudflare` → `@b9g/shovel`, then tag `v0.2.23` + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmBa71chuLM78aDA4LKvf4