### PR TITLE
fix(cloudflare): resolve the manifest registry from the platform package

### DIFF
--- a/packages/assets/src/manifest.ts
+++ b/packages/assets/src/manifest.ts
@@ -3,14 +3,18 @@
  *
  * The build bundles the manifest into the worker as the `shovel:assets`
  * virtual module, and the generated worker entry registers it here at
- * startup. Library code (directory handles, middleware) reads it through
- * this registry instead of importing `shovel:assets` directly — a static
+ * startup. Directory handles read it through this registry instead of
+ * importing `shovel:assets` directly — a static
  * `import("shovel:assets")` in library source breaks any consumer bundling
  * outside a shovel build (plain wrangler/esbuild/Vite cannot resolve the
  * virtual module), whereas the generated entry only exists in shovel builds.
  *
  * This module is dependency-free so registering the manifest doesn't drag
  * middleware code (mime, caching) into every worker bundle.
+ *
+ * The assets middleware still loads `shovel:assets` itself (its dev-mode
+ * re-import semantics differ, and node/bun entries don't register here yet);
+ * migrating it requires registering the manifest in every platform's entry.
  */
 
 import type {AssetManifest} from "./middleware.js";

--- a/packages/platform-cloudflare/src/index.ts
+++ b/packages/platform-cloudflare/src/index.ts
@@ -352,8 +352,7 @@ export class CloudflarePlatform {
 		const serverCode = `// Cloudflare Worker Entry
 import { config } from "shovel:config";
 import __shovelAssetsManifest from "shovel:assets";
-import { setAssetsManifest } from "@b9g/assets/manifest";
-import { initializeRuntime, createFetchHandler } from "@b9g/platform-cloudflare/runtime";
+import { initializeRuntime, createFetchHandler, setAssetsManifest } from "@b9g/platform-cloudflare/runtime";
 
 // Register the build's asset manifest so directory handles can enumerate
 // ASSETS without importing the virtual module from library code (which

--- a/packages/platform-cloudflare/src/platform.ts
+++ b/packages/platform-cloudflare/src/platform.ts
@@ -43,8 +43,7 @@ export function getEntryPoints(
 	const workerCode = `// Cloudflare Worker Entry
 import { config } from "shovel:config";
 import __shovelAssetsManifest from "shovel:assets";
-import { setAssetsManifest } from "@b9g/assets/manifest";
-import { initializeRuntime, createFetchHandler } from "@b9g/platform-cloudflare/runtime";
+import { initializeRuntime, createFetchHandler, setAssetsManifest } from "@b9g/platform-cloudflare/runtime";
 
 // Register the build's asset manifest so directory handles can enumerate
 // ASSETS without importing the virtual module from library code (which

--- a/packages/platform-cloudflare/src/runtime.ts
+++ b/packages/platform-cloudflare/src/runtime.ts
@@ -1,3 +1,10 @@
+// Re-exported so generated worker entries can register the asset manifest
+// via a specifier that resolves from this package's own dependency context
+// (a bare "@b9g/assets/manifest" import in a generated entry resolves from
+// the user's project root, which fails under pnpm-isolated layouts and can
+// bundle a second registry copy).
+export {setAssetsManifest} from "@b9g/assets/manifest";
+
 /**
  * Cloudflare Worker Runtime
  *

--- a/src/plugins/assets-manifest.ts
+++ b/src/plugins/assets-manifest.ts
@@ -159,10 +159,14 @@ export function createAssetsManifestPlugin(
 									});
 								}
 							} catch (err) {
-								logger.warn("Failed to update {file} with manifest: {error}", {
+								// Fail closed: an unreplaced placeholder is a ReferenceError
+								// at module evaluation for the whole worker, not a degraded
+								// feature. Surface it as a build failure.
+								logger.error("Failed to update {file} with manifest: {error}", {
 									file: jsFile,
 									error: err,
 								});
+								throw err;
 							}
 						}
 					}


### PR DESCRIPTION
Pre-publish review findings on #109, fixed before v0.2.23 ships:

- **CONFIRMED**: the generated worker entry imported `@b9g/assets/manifest` bare, resolving from the user's project root where `@b9g/assets` is only transitive — cloudflare builds fail under pnpm-isolated/Yarn-PnP ("Could not resolve @b9g/assets/manifest"); hoisted layouts (our CI) hide it. The setter is now re-exported from `@b9g/platform-cloudflare/runtime`, which the entry already imports and which resolves from the platform package's own context. This also guarantees one bundled registry copy (writer and reader can't split across duplicate installs).
- **PLAUSIBLE**: manifest placeholder replacement failures were warn-swallowed; with the entry importing `shovel:assets` uncaught, an unreplaced placeholder is a worker-wide `ReferenceError`. The onEnd replacement now fails the build (fail-closed, matching e64d6bb precedent).
- **CONFIRMED (docs)**: the registry docstring claimed middleware reads through it; it doesn't yet (node/bun entries don't register). Docstring corrected with the migration precondition.

32 unit + 6 e2e tests pass (the e2e exercises the new runtime-re-export path end to end) · tsc exit 0 · eslint exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmBa71chuLM78aDA4LKvf4