### PR TITLE
fix(build): manifest post-condition, error channel, and generated-entry resolution

### DIFF
--- a/packages/platform-bun/src/index.ts
+++ b/packages/platform-bun/src/index.ts
@@ -386,8 +386,7 @@ export class BunPlatform {
 		// Worker code for production (with message handling for supervisor communication)
 		const prodWorkerCode = `// Bun Production Worker
 import BunPlatform from "@b9g/platform-bun";
-import {getLogger} from "@logtape/logtape";
-import {configureLogging, initWorkerRuntime, runLifecycle, dispatchRequest, setBroadcastChannelRelay, deliverBroadcastMessage} from "@b9g/platform/runtime";
+import {getLogger, configureLogging, initWorkerRuntime, runLifecycle, dispatchRequest, setBroadcastChannelRelay, deliverBroadcastMessage} from "@b9g/platform/runtime";
 import {config} from "shovel:config";
 
 await configureLogging(config.logging);
@@ -466,8 +465,7 @@ startWorkerMessageLoop({registration, databases});
 
 		// Production: supervisor + worker
 		const supervisorCode = `// Bun Production Supervisor
-import {getLogger} from "@logtape/logtape";
-import {configureLogging} from "@b9g/platform/runtime";
+import {getLogger, configureLogging} from "@b9g/platform/runtime";
 import BunPlatform from "@b9g/platform-bun";
 import {config} from "shovel:config";
 

--- a/packages/platform-bun/src/platform.ts
+++ b/packages/platform-bun/src/platform.ts
@@ -74,8 +74,7 @@ startWorkerMessageLoop({registration, databases});
 	// Worker code for production (with message handling for supervisor communication)
 	const prodWorkerCode = `// Bun Production Worker
 import BunPlatform from "@b9g/platform-bun";
-import {getLogger} from "@logtape/logtape";
-import {configureLogging, initWorkerRuntime, runLifecycle, dispatchRequest} from "@b9g/platform/runtime";
+import {getLogger, configureLogging, initWorkerRuntime, runLifecycle, dispatchRequest} from "@b9g/platform/runtime";
 import {config} from "shovel:config";
 
 await configureLogging(config.logging);
@@ -122,8 +121,7 @@ logger.info("Worker started", {port: config.port});
 
 	// Production: supervisor + worker
 	const supervisorCode = `// Bun Production Supervisor
-import {getLogger} from "@logtape/logtape";
-import {configureLogging} from "@b9g/platform/runtime";
+import {getLogger, configureLogging} from "@b9g/platform/runtime";
 import BunPlatform from "@b9g/platform-bun";
 import {config} from "shovel:config";
 

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -13,6 +13,10 @@ import * as Path from "node:path";
 // External packages
 import {getLogger} from "@logtape/logtape";
 
+// Re-exported for generated supervisor entries (same transitive-resolution
+// rationale as @b9g/platform/runtime's getLogger re-export).
+export {Worker as NodeWebWorker} from "@b9g/node-webworker";
+
 // Internal @b9g/* packages
 import {CustomCacheStorage} from "@b9g/cache";
 import {InternalServerError, isHTTPError, HTTPError} from "@b9g/http-errors";
@@ -486,8 +490,7 @@ if (config.lifecycle) {
 		// - Multi-worker: uses message loop (supervisor owns the HTTP server)
 		const prodWorkerCode = `// Node.js Production Worker
 import {parentPort} from "node:worker_threads";
-import {getLogger} from "@logtape/logtape";
-import {configureLogging, initWorkerRuntime, runLifecycle, startWorkerMessageLoop, dispatchRequest} from "@b9g/platform/runtime";
+import {getLogger, configureLogging, initWorkerRuntime, runLifecycle, startWorkerMessageLoop, dispatchRequest} from "@b9g/platform/runtime";
 import NodePlatform from "@b9g/platform-node";
 import {config} from "shovel:config";
 
@@ -542,10 +545,8 @@ if (config.lifecycle) {
 
 		// Production: supervisor + worker
 		const supervisorCode = `// Node.js Production Supervisor
-import {Worker} from "@b9g/node-webworker";
-import {getLogger} from "@logtape/logtape";
-import {configureLogging} from "@b9g/platform/runtime";
-import NodePlatform from "@b9g/platform-node";
+import {getLogger, configureLogging} from "@b9g/platform/runtime";
+import NodePlatform, {NodeWebWorker as Worker} from "@b9g/platform-node";
 import {config} from "shovel:config";
 
 await configureLogging(config.logging);

--- a/packages/platform-node/src/platform.ts
+++ b/packages/platform-node/src/platform.ts
@@ -83,8 +83,7 @@ if (config.lifecycle) {
 	// - Multi-worker: uses message loop (supervisor owns the HTTP server)
 	const prodWorkerCode = `// Node.js Production Worker
 import {parentPort} from "node:worker_threads";
-import {getLogger} from "@logtape/logtape";
-import {configureLogging, initWorkerRuntime, runLifecycle, startWorkerMessageLoop, dispatchRequest} from "@b9g/platform/runtime";
+import {getLogger, configureLogging, initWorkerRuntime, runLifecycle, startWorkerMessageLoop, dispatchRequest} from "@b9g/platform/runtime";
 import NodePlatform from "@b9g/platform-node";
 import {config} from "shovel:config";
 
@@ -139,10 +138,8 @@ if (config.lifecycle) {
 
 	// Production: supervisor + worker
 	const supervisorCode = `// Node.js Production Supervisor
-import {Worker} from "@b9g/node-webworker";
-import {getLogger} from "@logtape/logtape";
-import {configureLogging} from "@b9g/platform/runtime";
-import NodePlatform from "@b9g/platform-node";
+import {getLogger, configureLogging} from "@b9g/platform/runtime";
+import NodePlatform, {NodeWebWorker as Worker} from "@b9g/platform-node";
 import {config} from "shovel:config";
 
 await configureLogging(config.logging);

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -12,6 +12,10 @@
 
 import {AsyncContext} from "@b9g/async-context";
 import {getLogger, getConsoleSink} from "@logtape/logtape";
+// Re-exported for generated worker entries: a bare "@logtape/logtape" import
+// in generated code resolves from the user's project root, where it is only
+// a transitive dependency (fails under pnpm-isolated/Yarn-PnP layouts).
+export {getLogger} from "@logtape/logtape";
 import {CustomDirectoryStorage} from "@b9g/filesystem";
 import {CustomCacheStorage, Cache} from "@b9g/cache";
 import {handleCacheResponse, PostMessageCache} from "@b9g/cache/postmessage";

--- a/src/commands/develop.ts
+++ b/src/commands/develop.ts
@@ -187,7 +187,13 @@ export async function developCommand(
 				switch (key) {
 					case "\x12": // Ctrl+R
 						logger.info("Manual reload...");
-						await bundler.rebuild();
+						try {
+							await bundler.rebuild();
+						} catch (err) {
+							// Mirror the watch path: a failed rebuild logs and keeps the
+							// dev server alive instead of dying on an unhandled rejection.
+							logger.error("Manual reload failed: {error}", {error: err});
+						}
 						break;
 					case "\x0C": // Ctrl+L
 						// eslint-disable-next-line no-console

--- a/src/plugins/assets-manifest.ts
+++ b/src/plugins/assets-manifest.ts
@@ -19,7 +19,13 @@
  */
 
 import * as ESBuild from "esbuild";
-import {existsSync, readFileSync, writeFileSync} from "node:fs";
+import {
+	existsSync,
+	readFileSync,
+	writeFileSync,
+	readdirSync,
+	renameSync,
+} from "node:fs";
 import {join, isAbsolute} from "node:path";
 import {getLogger} from "@logtape/logtape";
 
@@ -139,36 +145,73 @@ export function createAssetsManifestPlugin(
 					}
 				} else {
 					// When write: true, we need to read/modify/write the files
-					// This is the production build case
+					// This is the production build case. The scan is directory-driven
+					// (not a hardcoded name list) so any emitted server bundle —
+					// worker.js, index.js, supervisor.js, future names — is covered.
 					const serverDir = join(absoluteOutDir, "server");
-					const jsFiles = ["worker.js", "index.js"];
+					const errors: ESBuild.PartialMessage[] = [];
+
+					let jsFiles: string[] = [];
+					try {
+						jsFiles = readdirSync(serverDir).filter((f) => f.endsWith(".js"));
+					} catch (err) {
+						return {
+							errors: [
+								{
+									text: `assets manifest: cannot read ${serverDir}`,
+									detail: err,
+								},
+							],
+						};
+					}
 
 					for (const jsFile of jsFiles) {
 						const filePath = join(serverDir, jsFile);
-						if (existsSync(filePath)) {
-							try {
-								const content = readFileSync(filePath, "utf8");
-								if (content.includes(MANIFEST_PLACEHOLDER)) {
-									const newContent = content.replace(
-										MANIFEST_PLACEHOLDER,
-										() => manifestContent,
-									);
-									writeFileSync(filePath, newContent, "utf8");
-									logger.debug("Updated {file} with asset manifest", {
-										file: jsFile,
-									});
-								}
-							} catch (err) {
-								// Fail closed: an unreplaced placeholder is a ReferenceError
-								// at module evaluation for the whole worker, not a degraded
-								// feature. Surface it as a build failure.
-								logger.error("Failed to update {file} with manifest: {error}", {
+						try {
+							const content = readFileSync(filePath, "utf8");
+							if (content.includes(MANIFEST_PLACEHOLDER)) {
+								const newContent = content.replace(
+									MANIFEST_PLACEHOLDER,
+									() => manifestContent,
+								);
+								// Write-then-rename so a failed write can't leave a
+								// truncated, deployable-looking bundle behind.
+								const tmpPath = filePath + ".tmp";
+								writeFileSync(tmpPath, newContent, "utf8");
+								renameSync(tmpPath, filePath);
+								logger.debug("Updated {file} with asset manifest", {
 									file: jsFile,
-									error: err,
 								});
-								throw err;
 							}
+						} catch (err) {
+							errors.push({
+								text: `Failed to update ${jsFile} with asset manifest`,
+								detail: err,
+							});
 						}
+					}
+
+					// Post-condition, fail closed: an unreplaced placeholder is a
+					// ReferenceError at module evaluation for the whole worker, not
+					// a degraded feature. No emitted bundle may still contain it.
+					for (const jsFile of jsFiles) {
+						try {
+							const content = readFileSync(join(serverDir, jsFile), "utf8");
+							if (content.includes(MANIFEST_PLACEHOLDER)) {
+								errors.push({
+									text:
+										`${jsFile} still contains the asset manifest ` +
+										`placeholder after replacement`,
+								});
+							}
+						} catch (err) {
+							// Read failure here was already reported by the loop above.
+							logger.debug("post-condition re-read failed", {err});
+						}
+					}
+
+					if (errors.length > 0) {
+						return {errors};
 					}
 				}
 			});


### PR DESCRIPTION
Round 3 of the pre-publish adversarial review loop (on #111's diff). Four CONFIRMED + one PLAUSIBLE finding, all fixed:

1. **Placeholder post-condition (CONFIRMED)** — the replacement loop's hardcoded `["worker.js", "index.js"]` silently skipped other emitted bundles (platform-node emits `supervisor.js`); a missing file or unreplaced placeholder passed the build and died at module evaluation in production. Now directory-driven over `dist/server/*.js` with a fail-closed post-condition scan.
2. **Same-class resolution bug on node/bun (CONFIRMED)** — generated entries imported `@logtape/logtape` / `@b9g/node-webworker` bare, resolving from the user's project root (breaks pnpm-isolated/Yarn-PnP, exactly like #111's cloudflare case). Routed through `@b9g/platform/runtime` (`getLogger`) and `@b9g/platform-node` (`NodeWebWorker`); all four dual-file templates updated.
3. **Partial state on mid-loop throw (CONFIRMED)** — one file's failure aborted patching the rest and could leave a truncated bundle; now per-file error collection + write-then-rename atomicity.
4. **Error channel (CONFIRMED)** — `logger.error` + `throw` triple-reported through esbuild's wrap and the CLI's unhandled rejection; now a single `return {errors}` like sibling plugins.
5. **Ctrl+R unhandled rejection (PLAUSIBLE)** — `shovel develop`'s manual reload awaited `rebuild()` unguarded; a manifest-patch failure would kill the dev server. Wrapped, mirroring the watch path.

**Verification**: 266 tests across platform/node/bun/cloudflare/build/e2e-bundling pass (e2e-bundling runs the built node bundles, exercising the changed templates), 6/6 cloudflare-build e2e, tsc exit 0, eslint exit 0 — all unpiped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmBa71chuLM78aDA4LKvf4