### PR TITLE
fix(build): manifest onEnd guards, folded post-condition, platform version bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to Shovel will be documented in this file.
 
 ### Dependencies
 
-- `@b9g/platform-cloudflare` 0.1.19, `@b9g/assets` 0.2.2
+- `@b9g/platform-cloudflare` 0.1.19, `@b9g/assets` 0.2.2, `@b9g/platform` 0.1.20, `@b9g/platform-node` 0.1.18, `@b9g/platform-bun` 0.1.18 (generated-entry import resolution + manifest registry)
 
 ## [0.2.22] - 2026-08-11
 

--- a/packages/platform-bun/package.json
+++ b/packages/platform-bun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b9g/platform-bun",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Bun platform adapter for Shovel with hot reloading and built-in TypeScript/JSX support",
   "type": "module",
   "scripts": {

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b9g/platform-node",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Node.js platform adapter for Shovel with hot reloading and ESBuild integration",
   "type": "module",
   "scripts": {

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b9g/platform",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "The portable meta-framework built on web standards.",
   "type": "module",
   "scripts": {

--- a/src/commands/develop.ts
+++ b/src/commands/develop.ts
@@ -187,13 +187,8 @@ export async function developCommand(
 				switch (key) {
 					case "\x12": // Ctrl+R
 						logger.info("Manual reload...");
-						try {
-							await bundler.rebuild();
-						} catch (err) {
-							// Mirror the watch path: a failed rebuild logs and keeps the
-							// dev server alive instead of dying on an unhandled rejection.
-							logger.error("Manual reload failed: {error}", {error: err});
-						}
+						// Bundler.rebuild() owns log-and-survive for failed rebuilds.
+						await bundler.rebuild();
 						break;
 					case "\x0C": // Ctrl+L
 						// eslint-disable-next-line no-console

--- a/src/plugins/assets-manifest.ts
+++ b/src/plugins/assets-manifest.ts
@@ -25,8 +25,9 @@ import {
 	writeFileSync,
 	readdirSync,
 	renameSync,
+	unlinkSync,
 } from "node:fs";
-import {join, isAbsolute} from "node:path";
+import {join, isAbsolute, resolve, basename} from "node:path";
 import {getLogger} from "@logtape/logtape";
 
 const logger = getLogger(["shovel", "assets"]);
@@ -122,6 +123,10 @@ export function createAssetsManifestPlugin(
 
 			// After build completes, replace placeholder with actual manifest
 			build.onEnd((result) => {
+				// A failed build must not touch dist: rewriting whatever a prior
+				// build left there would stamp this build's manifest into stale
+				// bundles and make a broken dist look deployable.
+				if (result.errors.length > 0) return;
 				if (!sharedManifest) return;
 
 				// Generate final manifest content
@@ -135,7 +140,7 @@ export function createAssetsManifestPlugin(
 							// Replacement via function: the manifest JSON contains
 							// user file paths, and string replacement would interpret
 							// $-patterns ($&, $', $`) in them.
-							const newText = file.text.replace(
+							const newText = file.text.replaceAll(
 								MANIFEST_PLACEHOLDER,
 								() => manifestContent,
 							);
@@ -151,62 +156,86 @@ export function createAssetsManifestPlugin(
 					const serverDir = join(absoluteOutDir, "server");
 					const errors: ESBuild.PartialMessage[] = [];
 
+					// Scope the scan to this build's own outputs when the metafile
+					// is available (stale bundles from prior builds are not this
+					// build's invariant to enforce); fall back to a directory scan.
 					let jsFiles: string[] = [];
+					const metaOutputs = result.metafile
+						? Object.keys(result.metafile.outputs)
+								.map((o) => resolve(o))
+								.filter((o) => o.startsWith(serverDir) && o.endsWith(".js"))
+								.map((o) => basename(o))
+						: null;
+					if (metaOutputs && metaOutputs.length > 0) {
+						jsFiles = metaOutputs;
+					} else {
+						try {
+							jsFiles = readdirSync(serverDir).filter((f) => f.endsWith(".js"));
+						} catch (err) {
+							return {
+								errors: [
+									{
+										text: `assets manifest: cannot read ${serverDir}`,
+										detail: err,
+									},
+								],
+							};
+						}
+					}
+
+					// Best-effort sweep of orphaned temp files from interrupted
+					// prior builds (write-then-rename leftovers).
 					try {
-						jsFiles = readdirSync(serverDir).filter((f) => f.endsWith(".js"));
+						for (const f of readdirSync(serverDir)) {
+							if (f.endsWith(".js.tmp")) {
+								unlinkSync(join(serverDir, f));
+							}
+						}
 					} catch (err) {
-						return {
-							errors: [
-								{
-									text: `assets manifest: cannot read ${serverDir}`,
-									detail: err,
-								},
-							],
-						};
+						logger.debug("tmp sweep skipped", {err});
 					}
 
 					for (const jsFile of jsFiles) {
 						const filePath = join(serverDir, jsFile);
+						const tmpPath = filePath + ".tmp";
 						try {
 							const content = readFileSync(filePath, "utf8");
-							if (content.includes(MANIFEST_PLACEHOLDER)) {
-								const newContent = content.replace(
-									MANIFEST_PLACEHOLDER,
-									() => manifestContent,
-								);
-								// Write-then-rename so a failed write can't leave a
-								// truncated, deployable-looking bundle behind.
-								const tmpPath = filePath + ".tmp";
-								writeFileSync(tmpPath, newContent, "utf8");
-								renameSync(tmpPath, filePath);
-								logger.debug("Updated {file} with asset manifest", {
-									file: jsFile,
-								});
-							}
-						} catch (err) {
-							errors.push({
-								text: `Failed to update ${jsFile} with asset manifest`,
-								detail: err,
-							});
-						}
-					}
+							if (!content.includes(MANIFEST_PLACEHOLDER)) continue;
 
-					// Post-condition, fail closed: an unreplaced placeholder is a
-					// ReferenceError at module evaluation for the whole worker, not
-					// a degraded feature. No emitted bundle may still contain it.
-					for (const jsFile of jsFiles) {
-						try {
-							const content = readFileSync(join(serverDir, jsFile), "utf8");
-							if (content.includes(MANIFEST_PLACEHOLDER)) {
+							const newContent = content.replaceAll(
+								MANIFEST_PLACEHOLDER,
+								() => manifestContent,
+							);
+							// Fail closed, verified in memory: rename success below
+							// implies the on-disk content equals newContent, so this
+							// check IS the post-condition — no re-read, no window for
+							// a swallowed verification failure.
+							if (newContent.includes(MANIFEST_PLACEHOLDER)) {
 								errors.push({
 									text:
 										`${jsFile} still contains the asset manifest ` +
 										`placeholder after replacement`,
 								});
+								continue;
 							}
+							// Write-then-rename so a failed write can't leave a
+							// truncated, deployable-looking bundle behind.
+							writeFileSync(tmpPath, newContent, "utf8");
+							renameSync(tmpPath, filePath);
+							logger.debug("Updated {file} with asset manifest", {
+								file: jsFile,
+							});
 						} catch (err) {
-							// Read failure here was already reported by the loop above.
-							logger.debug("post-condition re-read failed", {err});
+							errors.push({
+								text: `Failed to update ${jsFile} with asset manifest`,
+								detail: err,
+							});
+							try {
+								unlinkSync(tmpPath);
+							} catch (cleanupErr) {
+								// Nothing to clean when the failure preceded the write.
+								logger.debug("tmp cleanup skipped", {cleanupErr});
+							}
 						}
 					}
 

--- a/src/utils/bundler.ts
+++ b/src/utils/bundler.ts
@@ -225,7 +225,14 @@ export class ServerBundler {
 			throw new Error("Cannot rebuild: bundler is not in watch mode");
 		}
 
-		await this.#ctx.rebuild();
+		// Log-and-survive is this method's contract: every caller (watch
+		// debounce, Ctrl+R) wants the dev server to outlive a failed rebuild,
+		// so the catch lives here instead of at each call site.
+		try {
+			await this.#ctx.rebuild();
+		} catch (err) {
+			logger.error("Rebuild failed: {error}", {error: err});
+		}
 	}
 
 	/**


### PR DESCRIPTION
Round 5 of the pre-publish review loop (on #112's diff). Fixes the 5 in-scope survivors and the version gap:

1. **Failed-build guard (CONFIRMED)** — `onEnd` ran its rewrite even when `result.errors` was non-empty, injecting a failed build's manifest into stale bundles. Early return added.
2. **Post-condition folded in-memory (CONFIRMED)** — the re-read verification loop could swallow its own failure and pass an unverified bundle; verification now happens on `newContent` before the atomic write (rename success ⇒ disk === verified content). Deletes the swallowed-error branch and halves reads.
3. **`replaceAll` (PLAUSIBLE)** — multiple placeholder occurrences no longer hard-fail the build; both branches.
4. **Metafile-scoped scan + tmp hygiene (CONFIRMED/PLAUSIBLE)** — the scan prefers this build's own outputs; orphaned `*.js.tmp` swept; failed rename unlinks its temp file.
5. **Centralized rebuild catch (CONFIRMED cleanup)** — `Bundler.rebuild()` owns log-and-survive; duplicate wrappers removed.

**Version audit** (user-requested): every pending publish is exactly +1 from npm. #112 changed `@b9g/platform`, `@b9g/platform-node`, `@b9g/platform-bun` without bumping them — publishing shovel without these would generate entries importing re-exports the npm versions lack. Bumped: platform 0.1.19→0.1.20, platform-node 0.1.17→0.1.18, platform-bun 0.1.17→0.1.18. CHANGELOG dependencies line updated.

**Deferred** (pre-existing, filed for follow-up): generated entries still bare-import `@b9g/platform/runtime`, itself transitive for scaffolded apps — same class, needs re-export plumbing through platform-node/bun across all four templates.

**Verification**: 266 tests (platform × 4, build, e2e-bundling) + 6 cloudflare e2e pass · tsc exit 0 · eslint exit 0 — unpiped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmBa71chuLM78aDA4LKvf4