### PR TITLE
fix(build): resolve metafile output paths against absWorkingDir

### DIFF
--- a/src/plugins/assets-manifest.ts
+++ b/src/plugins/assets-manifest.ts
@@ -160,12 +160,18 @@ export function createAssetsManifestPlugin(
 					// is available (stale bundles from prior builds are not this
 					// build's invariant to enforce); fall back to a directory scan.
 					let jsFiles: string[] = [];
-					const metaOutputs = result.metafile
-						? Object.keys(result.metafile.outputs)
-								.map((o) => resolve(o))
-								.filter((o) => o.startsWith(serverDir) && o.endsWith(".js"))
-								.map((o) => basename(o))
-						: null;
+					// Metafile output keys are relative to esbuild's absWorkingDir
+					// (the project root), not necessarily the process cwd. Without
+					// absWorkingDir there is no reliable base, so fall back to the
+					// directory scan.
+					const metaBase = build.initialOptions.absWorkingDir;
+					const metaOutputs =
+						result.metafile && metaBase
+							? Object.keys(result.metafile.outputs)
+									.map((o) => resolve(metaBase, o))
+									.filter((o) => o.startsWith(serverDir) && o.endsWith(".js"))
+									.map((o) => basename(o))
+							: null;
 					if (metaOutputs && metaOutputs.length > 0) {
 						jsFiles = metaOutputs;
 					} else {


### PR DESCRIPTION
Closes the final open candidate from review round 6 (the other nine were refuted). Metafile output keys are relative to esbuild's `absWorkingDir`, not the process cwd; resolving against cwd could silently disable the metafile-scoped scan (benign — it degrades to the directory-scan fallback — but the scoping exists for a reason). Without `absWorkingDir` the fallback is now explicit.

tsc exit 0 · eslint exit 0 · 6/6 cloudflare-build e2e (plus build/e2e-bundling suites on the parent commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmBa71chuLM78aDA4LKvf4